### PR TITLE
Format landing page table and resolve URL

### DIFF
--- a/src/semra/client.py
+++ b/src/semra/client.py
@@ -130,7 +130,7 @@ class Neo4jClient:
     def _get_node_by_curie(self, curie: ReferenceHint, node_type: str | None = None) -> Node:
         if isinstance(curie, Reference):
             curie = curie.curie
-        query = "MATCH (n%s {curie: $curie}) RETURN n" % (':' + node_type if node_type else "")
+        query = "MATCH (n%s {curie: $curie}) RETURN n" % (":" + node_type if node_type else "")
         res = self.read_query(query, curie=curie)
         return res[0][0]
 
@@ -187,7 +187,7 @@ class Neo4jClient:
         """Get all mappings sets."""
         query = "MATCH (m:mappingset) RETURN m"
         records = self.read_query(query)
-        return [MappingSet.parse_obj(record) for (record,) in records]
+        return [MappingSet.model_validate(record) for (record,) in records]
 
     def get_mapping_set(self, curie: ReferenceHint) -> MappingSet:
         """Get a mappings set.

--- a/src/semra/client.py
+++ b/src/semra/client.py
@@ -162,7 +162,7 @@ class Neo4jClient:
         for evidence_node, mapping_set_node, author_curie in evidence_pairs:
             evidence_dict = dict(evidence_node)
             if mapping_set_node:
-                evidence_dict["mapping_set"] = MappingSet.parse_obj(mapping_set_node)
+                evidence_dict["mapping_set"] = MappingSet.model_validate(mapping_set_node)
             if author_curie:
                 evidence_dict["author"] = Reference.from_curie(author_curie)
             evidence_dict["evidence_type"] = evidence_dict.pop("type")

--- a/src/semra/templates/base.html
+++ b/src/semra/templates/base.html
@@ -44,7 +44,7 @@
     <p class="small text-center text-muted">
         Developed with ❤️ by the <a href="https://gyorilab.github.io">Gyori Lab</a>.<br/>
         Point of contact: <a href="https://github.com/cthoyt">@cthoyt</a>.
-        (<a href="https://github.com/biomappings/semra">Source code</a>)
+        (<a href="https://github.com/biopragmatics/semra">Source code</a>)
     </p>
 </footer>
 

--- a/src/semra/templates/home.html
+++ b/src/semra/templates/home.html
@@ -106,8 +106,7 @@
                         <td class="text-break">
                             {% if mapping_set.license %}
                                 {% if mapping_set.license.startswith('http') %}
-                                    <a href="{{ mapping_set.license }}"
-                                       target="_blank">See link</a>
+                                    See <a href="{{ mapping_set.license }}" target="_blank">homepage</a>
                                 {% else %}
                                     {{ mapping_set.license }}
                                 {% endif %}

--- a/src/semra/templates/home.html
+++ b/src/semra/templates/home.html
@@ -104,7 +104,14 @@
                         </td>
                         <td class="text-nowrap">{{ mapping_set.version }}</td>
                         <td class="text-break">
-                            {% if mapping_set.license %}{{ mapping_set.license }}{% endif %}
+                            {% if mapping_set.license %}
+                                {% if mapping_set.license.startswith('http') %}
+                                    <a href="{{ mapping_set.license }}"
+                                       target="_blank">See link</a>
+                                {% else %}
+                                    {{ mapping_set.license }}
+                                {% endif %}
+                            {% endif %}
                         </td>
                         <td>{{ mapping_set.confidence }}</td>
                         <td align="right">{{ "{:,}".format(mapping_set_counter[mapping_set.curie]) }}</td>

--- a/src/semra/templates/home.html
+++ b/src/semra/templates/home.html
@@ -97,10 +97,15 @@
                     </tr>
                     {% for mapping_set in mapping_sets %}
                     <tr>
-                        <td><a href="{{ url_for('view_mapping_set', curie=mapping_set.curie) }}">{{ mapping_set.name
-                            }}</a></td>
-                        <td>{{ mapping_set.version }}</td>
-                        <td>{% if mapping_set.license %}{{ mapping_set.license }}{% endif %}</td>
+                        <td class="text-break">
+                            <a href="{{ url_for('view_mapping_set', curie=mapping_set.curie) }}">
+                                {{ mapping_set.name }}
+                            </a>
+                        </td>
+                        <td class="text-nowrap">{{ mapping_set.version }}</td>
+                        <td class="text-break">
+                            {% if mapping_set.license %}{{ mapping_set.license }}{% endif %}
+                        </td>
                         <td>{{ mapping_set.confidence }}</td>
                         <td align="right">{{ "{:,}".format(mapping_set_counter[mapping_set.curie]) }}</td>
                     </tr>

--- a/src/semra/templates/home.html
+++ b/src/semra/templates/home.html
@@ -98,7 +98,7 @@
                     {% for mapping_set in mapping_sets %}
                     <tr>
                         <td class="text-break">
-                            <a href="{{ url_for('view_mapping_set', curie=mapping_set.curie) }}">
+                            <a href="{{ url_for('view_mapping_set', mapping_set_id=mapping_set.curie) }}">
                                 {{ mapping_set.name }}
                             </a>
                         </td>

--- a/src/semra/wsgi.py
+++ b/src/semra/wsgi.py
@@ -180,7 +180,7 @@ def mark_exact_incorrect(source: str, target: str):
     return flask.redirect(flask.url_for(view_concept.__name__, curie=source))
 
 
-@flask_app.get("/mapping_set/{mapping_set_id}")
+@flask_app.get("/mapping_set/<mapping_set_id>")
 def view_mapping_set(mapping_set_id: str):
     """View a mapping set by its ID."""
     mapping_set = client.get_mapping_set(mapping_set_id)


### PR DESCRIPTION
## Summary

- The landing page Mapping Sets table was badly formatted, I added some bootstrap 5 classes to fix that: 63d4b954ae6ebfd156b85bd43d35be93c6f59181
- An instance of calling `url_for` for `/mapping_set/<mapping_set_id>` had the wrong argument, that's fixed: 4fb82ab0bcdd3331ca2d58b9b5132f56cc782270
- The `flask_app` endpoint for `/mapping_set/<mapping_set_id>` followed the syntax of a FastAPI endpoint, i.e. `/mapping_set/{mapping_set_id}`, and was therefore broken. It now, correctly, follows Flask syntax: bb1b152b152073872f2b45fe6c300f4af53a1dfa
- In the case where a license is a link, replace the URL with an `<a>` tag with shorter text: b09edba92a29ca389dc7f0585b31c9b62f475518 and e7b9a24d7ad0f9d9294435e46774b595621d21da
