### PR TITLE
Refactor mutation inference implementation and improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,14 +158,14 @@ predicate, like `owl:equivalentTo` to `skos:exactMatch`.
 
 ```python
 from semra import Reference, Mapping, EXACT_MATCH, EQUIVALENT_TO
-from semra.inference import infer_mutations
+from semra.inference import infer_generalizations
 
 r1 = Reference.from_curie("chebi:101854", name="talarozole")
 r2 = Reference.from_curie("chembl.compound:CHEMBL459505", name="TALAROZOLE")
 
 m1 = Mapping(s=r1, p=EXACT_MATCH, o=r2)
 
-mappings = infer_mutations([m1], {('chebi', 'chembl.compound'): 1.0}, EQUIVALENT_TO, EXACT_MATCH)
+mappings = infer_generalizations([m1])
 ```
 
 ```mermaid

--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ omim_gene_mappings = get_omim_gene_mappings()
 ### Inference
 
 SeMRA implements the chaining and inference rules described in the
-[SSSOM](https://mapping-commons.github.io/sssom/chaining-rules/) specification
+[SSSOM](https://mapping-commons.github.io/sssom/chaining-rules/) specification.
+The first rule is
+[inversions](https://mapping-commons.github.io/sssom/chaining-rules/#inverse-rules):
 
 ```python
 from semra import Mapping, EXACT_MATCH, Reference
@@ -122,6 +124,11 @@ graph LR
     B -. "skos:exactMatch<br/>(inferred)" .-> A
 ```
 
+The second rule is about
+[transitivity](https://mapping-commons.github.io/sssom/chaining-rules/#transitivity-rule).
+This means some predicates apply over chains. SeMRA further implements
+configuration for two-length chains and could be extended to arbitrary chains.
+
 ```python
 from semra import Reference, Mapping, EXACT_MATCH
 from semra.inference import infer_chains
@@ -143,6 +150,12 @@ graph LR
     B -- skos:exactMatch --> C[TALAROZOLE<br/>chembl.compound:CHEMBL459505]
     A -. "skos:exactMatch<br/>(inferred)" .-> C
 ```
+
+The last inference type is a generalization of the "Generalization" rule to
+enable bringing domain knowledge about how curation is done. For example, some
+resources curate `oboInOwl:hasDbXref` predicates when it's implied that they
+mean `skos:exactMatch` because the resource is curated in the OBO flat file
+format.
 
 ```python
 from semra import Reference, Mapping, DB_XREF

--- a/README.md
+++ b/README.md
@@ -94,6 +94,49 @@ from semra.sources import get_omim_gene_mappings
 omim_gene_mappings = get_omim_gene_mappings()
 ```
 
+SeMRA implements the chaining and inference rules described in the
+[SSSOM](https://mapping-commons.github.io/sssom/chaining-rules/) specification
+
+```python
+from semra import Mapping, EXACT_MATCH, Reference
+from semra.inference import infer_reversible
+
+# infer reversible
+mapping = Mapping(
+   s=Reference(prefix="chebi", identifier="107635", name="2,3-diacetyloxybenzoic"),
+   p=EXACT_MATCH,
+   o=Reference(prefix="mesh", identifier="C011748", name="tosiben"),
+)
+
+# includes the mesh -> exact match-> chebi mapping with full provenance
+mappings = infer_reversible([mapping])
+```
+
+```mermaid
+graph LR
+    A[2,3-diacetyloxybenzoic\nCHEBI:107635] -- Link text --> B((Circle))
+    A --> C(Round Rect)
+    B --> D{Rhombus}
+    C --> D
+```
+
+
+```python
+from semra import Reference, Mapping, EXACT_MATCH
+from semra.inference import infer_chains
+
+r1 = Reference.from_curie("mesh:C406527", name="R 115866")
+r2 = Reference.from_curie("chebi:101854", name="talarozole")
+r3 = Reference.from_curie("chembl.compound:CHEMBL459505", name="TALAROZOLE")
+
+m1 = Mapping(s=r1, p=EXACT_MATCH, o=r2)
+m2 = Mapping(s=r2, p=EXACT_MATCH, o=r3)
+
+# infers r1 -> exact match -> r3
+mappings = infer_chains([m1, m2])
+```
+
+
 Mappings can be processed, aggregated, and summarized using functions from the
 [`semra.api`]() submodule:
 

--- a/README.md
+++ b/README.md
@@ -151,11 +151,33 @@ graph LR
     A -. "skos:exactMatch<br/>(inferred)" .-> C
 ```
 
-The last inference type is a generalization of the "Generalization" rule to
-enable bringing domain knowledge about how curation is done. For example, some
-resources curate `oboInOwl:hasDbXref` predicates when it's implied that they
-mean `skos:exactMatch` because the resource is curated in the OBO flat file
-format.
+The third rule is
+[generalization](https://mapping-commons.github.io/sssom/chaining-rules/#generalisation-rules),
+which means that a more strict predicate can be relaxed to a less specific
+predicate, like `owl:equivalentTo` to `skos:exactMatch`.
+
+```python
+from semra import Reference, Mapping, EXACT_MATCH, EQUIVALENT_TO
+from semra.inference import infer_mutations
+
+r1 = Reference.from_curie("chebi:101854", name="talarozole")
+r2 = Reference.from_curie("chembl.compound:CHEMBL459505", name="TALAROZOLE")
+
+m1 = Mapping(s=r1, p=EXACT_MATCH, o=r2)
+
+mappings = infer_mutations([m1], {('chebi', 'chembl.compound'): 1.0}, EQUIVALENT_TO, EXACT_MATCH)
+```
+
+```mermaid
+graph LR
+    A[talarozole<br/>chebi:101854] -- owl:equivalentTo --> B[TALAROZOLE<br/>chembl.compound:CHEMBL459505]
+    A -. "skos:exactMatch<br/>(inferred)" .-> B
+```
+
+The third rule can actually be generalized to any kinds of mutation of one
+predicate to another, given some domain knowledge. For example, some resources
+curate `oboInOwl:hasDbXref` predicates when it's implied that they mean
+`skos:exactMatch` because the resource is curated in the OBO flat file format.
 
 ```python
 from semra import Reference, Mapping, DB_XREF

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ mappings = infer_reversible([mapping])
 
 ```mermaid
 graph LR
-    A[2,3-diacetyloxybenzoic<br/>CHEBI:107635] -- skos:exactMatch --> B[tosiben<br/>mesh:C011748]
+    A[2,3-diacetyloxybenzoic<br/>chebi:107635] -- skos:exactMatch --> B[tosiben<br/>mesh:C011748]
     B -. "skos:exactMatch<br/>(inferred)" .-> A
 ```
 
@@ -142,6 +142,24 @@ graph LR
     A[R 115866<br/>mesh:C406527] -- skos:exactMatch --> B[talarozole<br/>chebi:101854]
     B -- skos:exactMatch --> C[TALAROZOLE<br/>chembl.compound:CHEMBL459505]
     A -. "skos:exactMatch<br/>(inferred)" .-> C
+```
+
+```python
+from semra import Reference, Mapping, DB_XREF
+from semra.inference import infer_dbxref_mutations
+
+r1 = Reference.from_curie("doid:0050577", name="cranioectodermal dysplasia")
+r2 = Reference.from_curie("mesh:C562966", name="Cranioectodermal Dysplasia")
+m1 = Mapping(s=r1, p=DB_XREF, o=r2)
+
+# we're 99% confident doid-mesh dbxrefs actually are exact matches
+mappings = infer_dbxref_mutations([m1], {("doid", "mesh"): 0.99})
+```
+
+```mermaid
+graph LR
+    A[cranioectodermal dysplasia<br/>doid:0050577] -- oboInOwl:hasDbXref --> B[Cranioectodermal Dysplasia<br/>mesh:C562966]
+    A -. "skos:exactMatch<br/>(inferred)" .-> B
 ```
 
 ### Processing

--- a/README.md
+++ b/README.md
@@ -115,9 +115,8 @@ mappings = infer_reversible([mapping])
 ```mermaid
 graph LR
     A[2,3-diacetyloxybenzoic<br/>CHEBI:107635] -- skos:exactMatch --> B[tosiben<br/>mesh:C011748]
-    B -.- skos:exactMatch -.-> A
+    B -. "skos:exactMatch (inferred)" .-> A
 ```
-
 
 ```python
 from semra import Reference, Mapping, EXACT_MATCH

--- a/README.md
+++ b/README.md
@@ -114,10 +114,8 @@ mappings = infer_reversible([mapping])
 
 ```mermaid
 graph LR
-    A[2,3-diacetyloxybenzoic\nCHEBI:107635] -- Link text --> B((Circle))
-    A --> C(Round Rect)
-    B --> D{Rhombus}
-    C --> D
+    A[2,3-diacetyloxybenzoic<br/>CHEBI:107635] -- skos:exactMatch --> B[tosiben<br/>mesh:C011748]
+    B -.- skos:exactMatch -.-> A
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ mapping = Mapping(
 )
 ```
 
+### Assembly
+
 Mappings can be assembled from many source formats using functions in the
 `semra.io` submodule:
 
@@ -94,6 +96,8 @@ from semra.sources import get_omim_gene_mappings
 omim_gene_mappings = get_omim_gene_mappings()
 ```
 
+### Inference
+
 SeMRA implements the chaining and inference rules described in the
 [SSSOM](https://mapping-commons.github.io/sssom/chaining-rules/) specification
 
@@ -115,7 +119,7 @@ mappings = infer_reversible([mapping])
 ```mermaid
 graph LR
     A[2,3-diacetyloxybenzoic<br/>CHEBI:107635] -- skos:exactMatch --> B[tosiben<br/>mesh:C011748]
-    B -. "skos:exactMatch (inferred)" .-> A
+    B -. "skos:exactMatch<br/>(inferred)" .-> A
 ```
 
 ```python
@@ -133,6 +137,14 @@ m2 = Mapping(s=r2, p=EXACT_MATCH, o=r3)
 mappings = infer_chains([m1, m2])
 ```
 
+```mermaid
+graph LR
+    A[R 115866<br/>mesh:C406527] -- skos:exactMatch --> B[talarozole<br/>chebi:101854]
+    B -- skos:exactMatch --> C[TALAROZOLE<br/>chembl.compound:CHEMBL459505]
+    A -. "skos:exactMatch<br/>(inferred)" .-> C
+```
+
+### Processing
 
 Mappings can be processed, aggregated, and summarized using functions from the
 [`semra.api`]() submodule:

--- a/src/semra/__init__.py
+++ b/src/semra/__init__.py
@@ -4,6 +4,7 @@ from semra.pipeline import Configuration, Input, Mutation
 from semra.rules import (
     BROAD_MATCH,
     DB_XREF,
+    EQUIVALENT_TO,
     EXACT_MATCH,
     LEXICAL_MAPPING,
     MANUAL_MAPPING,
@@ -16,6 +17,7 @@ from semra.struct import Evidence, Mapping, MappingSet, ReasonedEvidence, Refere
 __all__ = [
     "BROAD_MATCH",
     "DB_XREF",
+    "EQUIVALENT_TO",
     "EXACT_MATCH",
     "LEXICAL_MAPPING",
     "MANUAL_MAPPING",

--- a/src/semra/inference.py
+++ b/src/semra/inference.py
@@ -9,6 +9,7 @@ from collections.abc import Iterable
 
 import bioregistry
 import networkx as nx
+from pydantic import BaseModel
 from tqdm.asyncio import tqdm
 
 from semra.api import assemble_evidences, flip
@@ -19,6 +20,7 @@ from semra.rules import (
     DB_XREF,
     EXACT_MATCH,
     FLIP,
+    GENERALIZATIONS,
     KNOWLEDGE_MAPPING,
     NARROW_MATCH,
 )
@@ -28,6 +30,7 @@ from semra.utils import cleanup_prefixes, semra_tqdm
 __all__ = [
     "infer_chains",
     "infer_dbxref_mutations",
+    "infer_generalizations",
     "infer_mutations",
     "infer_mutual_dbxref_mutations",
     "infer_reversible",
@@ -363,20 +366,56 @@ def infer_mutations(
     >>> mappings = infer_mutations([m1, m2], pairs, DB_XREF, EXACT_MATCH)
     >>> assert mappings == [m1, m3, m2]
     """
-    pairs = _clean_pairs(pairs)
+    configurations = [
+        Configuration(
+            old=old_predicate,
+            new=new_predicate,
+            pairs=_clean_pairs(pairs),
+        )
+    ]
+    return _mutate(mappings, configurations, progress=progress)
+
+
+class Configuration(BaseModel):
+    """A configuration for mutation."""
+
+    old: Reference
+    new: Reference
+    default_confidence: float | None = None
+    pairs: dict[tuple[str, str], float] | None = None
+
+
+def _mutate(
+    mappings: Iterable[Mapping],
+    configurations: list[Configuration],
+    *,
+    progress: bool = False,
+) -> list[Mapping]:
     rv = []
+
+    # index all configurations
+    upgrade_map = {c.old: c for c in configurations}
+
     for mapping in semra_tqdm(mappings, desc="Adding mutated predicates", progress=progress):
         rv.append(mapping)
-        if mapping.p != old_predicate:
+        configuration = upgrade_map.get(mapping.p)
+        if configuration is None:
             continue
-        confidence_factor = pairs.get((mapping.s.prefix, mapping.o.prefix))
+
+        if configuration.default_confidence:
+            confidence_factor = configuration.default_confidence
+        elif configuration.pairs:
+            confidence_factor = configuration.pairs.get((mapping.s.prefix, mapping.o.prefix))
+        else:
+            raise ValueError
+
         if confidence_factor is None:
             # This means that there was no explicit confidence set for the
             # subject/object prefix pair, meaning it wasn't asked to be inferred
             continue
         inferred_mapping = Mapping(
             s=mapping.s,
-            p=new_predicate,
+            p=configuration.new,
             o=mapping.o,
             evidence=[
                 ReasonedEvidence(
@@ -397,3 +436,16 @@ def _clean_pairs(pairs: dict[tuple[str, str], float]) -> dict[tuple[str, str], f
         p2_norm = bioregistry.normalize_prefix(p2, strict=True)
         rv[p1_norm, p2_norm] = v
     return rv
+
+
+def infer_generalizations(
+    mappings: list[Mapping],
+    *,
+    progress: bool = False,
+) -> list[Mapping]:
+    """Apply generalization rules."""
+    configurations = [
+        Configuration(old=old, new=new, default_confidence=1.0)
+        for old, new in GENERALIZATIONS.items()
+    ]
+    return _mutate(mappings, configurations, progress=progress)

--- a/src/semra/inference.py
+++ b/src/semra/inference.py
@@ -443,7 +443,16 @@ def infer_generalizations(
     *,
     progress: bool = False,
 ) -> list[Mapping]:
-    """Apply generalization rules."""
+    """Apply generalization rules.
+
+    :param mappings: Mappings to process
+    :param progress: Should a progress bar be used?
+    :returns:
+        Mappings that have been mutated to relax relations configured
+        by :data:`semra.rules.GENERALIZATIONS`
+
+    .. seealso:: Rules definition in SSSOM https://mapping-commons.github.io/sssom/chaining-rules/#generalisation-rules
+    """
     configurations = [
         Configuration(old=old, new=new, default_confidence=1.0)
         for old, new in GENERALIZATIONS.items()

--- a/src/semra/rules.py
+++ b/src/semra/rules.py
@@ -19,6 +19,7 @@ EXACT_MATCH = _f(v.exact_match)
 BROAD_MATCH = _f(v.broad_match)
 NARROW_MATCH = _f(v.narrow_match)
 CLOSE_MATCH = _f(v.close_match)
+SUBCLASS = _f(v.is_a)
 DB_XREF = _f(v.has_dbxref)
 EQUIVALENT_TO = Reference(prefix="owl", identifier="equivalentTo")
 REPLACED_BY = _f(v.term_replaced_by)
@@ -31,6 +32,7 @@ RELATIONS: list[Reference] = [
     CLOSE_MATCH,
     EQUIVALENT_TO,
     REPLACED_BY,
+    SUBCLASS,
 ]
 
 IMPRECISE: set[Reference] = {DB_XREF, CLOSE_MATCH}
@@ -53,6 +55,13 @@ TWO_STEP: dict[tuple[Reference, Reference], Reference] = {
     (EXACT_MATCH, BROAD_MATCH): BROAD_MATCH,
     (NARROW_MATCH, EXACT_MATCH): NARROW_MATCH,
     (EXACT_MATCH, NARROW_MATCH): NARROW_MATCH,
+}
+
+#: Rules for relaxing a more strict predicate to a more loose one,
+#: see https://mapping-commons.github.io/sssom/chaining-rules/#generalisation-rules
+GENERALIZATIONS = {
+    EQUIVALENT_TO: EXACT_MATCH,
+    SUBCLASS: BROAD_MATCH,
 }
 
 MANUAL_MAPPING = _f(v.manual_mapping_curation)


### PR DESCRIPTION
This PR does the following:

1. Refactors the way mutations are configured
2. Implements the SSSOM generalization rules https://mapping-commons.github.io/sssom/chaining-rules/#generalisation-rules
3. Adds more docs on the README