### PR TITLE
Update SSSOM implementation and example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ import semra.io
 
 # load mappings from any standardized SSSOM file as a file path or URL, via `pandas.read_csv`
 sssom_url = "https://w3id.org/biopragmatics/biomappings/sssom/biomappings.sssom.tsv"
-mappings = semra.io.from_sssom(sssom_url)
+mappings = semra.io.from_sssom(
+   sssom_url, license="spdx:CC0-1.0", mapping_set_name="biomappings", mapping_set_confidence=0.85,
+)
 
 # load mappings from the Gene Ontology (via OBO format)
 go_mappings = semra.io.from_pyobo("go")

--- a/README.md
+++ b/README.md
@@ -77,13 +77,12 @@ import semra.io
 # load mappings from any standardized SSSOM file as a file path or URL, via `pandas.read_csv`
 sssom_url = "https://w3id.org/biopragmatics/biomappings/sssom/biomappings.sssom.tsv"
 mappings = semra.io.from_sssom(
-   sssom_url, license="spdx:CC0-1.0", mapping_set_name="biomappings", mapping_set_confidence=0.85,
+   sssom_url, license="spdx:CC0-1.0", mapping_set_name="biomappings",
 )
 
 # alternatively, metadata can be passed via a file/URL
 mappings_alt = semra.io.from_sssom(
    sssom_url,
-   mapping_set_confidence=0.85,
    metadata="https://w3id.org/biopragmatics/biomappings/sssom/biomappings.sssom.yml"
 )
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ import semra.io
 # load mappings from any standardized SSSOM file as a file path or URL, via `pandas.read_csv`
 sssom_url = "https://w3id.org/biopragmatics/biomappings/sssom/biomappings.sssom.tsv"
 mappings = semra.io.from_sssom(
-   sssom_url, license="spdx:CC0-1.0", mapping_set_name="biomappings",
+   sssom_url, license="spdx:CC0-1.0", mapping_set_title="biomappings",
 )
 
 # alternatively, metadata can be passed via a file/URL

--- a/README.md
+++ b/README.md
@@ -76,10 +76,17 @@ import semra.io
 
 # load mappings from any standardized SSSOM file as a file path or URL, via `pandas.read_csv`
 sssom_url = "https://w3id.org/biopragmatics/biomappings/sssom/biomappings.sssom.tsv"
-sssom_metadata_url = "https://w3id.org/biopragmatics/biomappings/sssom/biomappings.sssom.yml"
 mappings = semra.io.from_sssom(
    sssom_url, license="spdx:CC0-1.0", mapping_set_name="biomappings", mapping_set_confidence=0.85,
 )
+
+# alternatively, metadata can be passed via a file/URL
+mappings_alt = semra.io.from_sssom(
+   sssom_url,
+   mapping_set_confidence=0.85,
+   metadata="https://w3id.org/biopragmatics/biomappings/sssom/biomappings.sssom.yml"
+)
+
 
 # load mappings from the Gene Ontology (via OBO format)
 go_mappings = semra.io.from_pyobo("go")

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ import semra.io
 
 # load mappings from any standardized SSSOM file as a file path or URL, via `pandas.read_csv`
 sssom_url = "https://w3id.org/biopragmatics/biomappings/sssom/biomappings.sssom.tsv"
+sssom_metadata_url = "https://w3id.org/biopragmatics/biomappings/sssom/biomappings.sssom.yml"
 mappings = semra.io.from_sssom(
    sssom_url, license="spdx:CC0-1.0", mapping_set_name="biomappings", mapping_set_confidence=0.85,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ dependencies = [
 tests = [
     "pytest",
     "coverage[toml]",
+    "sssom",
 ]
 docs = [
     "sphinx>=8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dependencies = [
     "curies>=0.10.9",
     "jinja2",  # used in neo4j generation
     "class-resolver>=0.6.0",
+    "pyyaml",
 ]
 
 [project.optional-dependencies]

--- a/src/semra/io/io.py
+++ b/src/semra/io/io.py
@@ -580,21 +580,20 @@ def _format_confidence(confidence: float) -> str:
 
 
 def _get_sssom_row(mapping: Mapping, e: Evidence, fallback_mapping_set_id: str) -> SSSOMRow:
-    # TODO increase this
     if isinstance(e, SimpleEvidence):
-        mapping_set_id = cast(str, e.mapping_set.id)
-        mapping_set_name = e.mapping_set.name
+        mapping_set_id = FALLBACK_MAPPING_SET_ID_URI_PREFIX + e.mapping_set.hexdigest()
+        mapping_set_title = e.mapping_set.name
         mapping_set_version = e.mapping_set.version or ""
-        mapping_set_license = e.mapping_set.license or ""
         mapping_set_confidence = get_confidence_str(e.mapping_set)
+        license = e.mapping_set.license or ""
         confidence = _format_confidence(e.confidence) if e.confidence else ""
     elif isinstance(e, ReasonedEvidence):
         # warning: SeMRA's format is not possible to capture in SSSOM
         mapping_set_id = fallback_mapping_set_id
-        mapping_set_name = "semra"
+        mapping_set_title = "semra"
         mapping_set_version = ""
-        mapping_set_license = ""
         mapping_set_confidence = "1.0"
+        license = ""
         confidence = _format_confidence(e.confidence_factor)
     else:
         raise TypeError
@@ -607,11 +606,11 @@ def _get_sssom_row(mapping: Mapping, e: Evidence, fallback_mapping_set_id: str) 
         object_label=mapping.o.name or "",
         mapping_justification=e.justification.curie,
         mapping_set_id=mapping_set_id,
-        mapping_set_title=mapping_set_name,
+        mapping_set_title=mapping_set_title,
         mapping_set_version=mapping_set_version,
         mapping_set_confidence=mapping_set_confidence,
         confidence=confidence,
-        license=mapping_set_license,
+        license=license,
         author_id=e.author.curie if e.author else "",
         author_label=e.author.name if e.author and e.author.name else "",
         comment=e.explanation,

--- a/src/semra/io/io.py
+++ b/src/semra/io/io.py
@@ -273,6 +273,7 @@ def from_sssom(
     mapping_set_id: str | None = None,
     mapping_set_name: str | None = None,
     mapping_set_confidence: float | None = None,
+    mapping_set_version: str | None = None,
     license: str | None = None,
     justification: Reference | None = None,
     version: str | None = None,
@@ -293,13 +294,14 @@ def from_sssom(
         specify its own confidence, but there is no global confidence at the set level.
 
         .. seealso:: https://github.com/mapping-commons/sssom/issues/438
+    :param mapping_set_version: The title for the SSSOM mapping set, if not given explicitly in each
+        mapping row nor by ``metadata``.
     :param license: The license for the SSSOM mapping set, if not given explicitly in
         each mapping row nor by ``metadata``.
     :param justification: The mapping justification for all mappings in the SSSOM
         mapping set, if not given explicitly in each mapping row nor by ``metadata``.
         Given as a :class:`curies.Reference` object using ``semapv`` as the prefix.
-    :param version: The title for the SSSOM mapping set, if not given explicitly in each
-        mapping row nor by ``metadata``.
+    :param version: Deprecated name for ``mapping_set_version``
     :param standardize: Should Bioregistry be applied to standardize all
     :param metadata: A URL to a SSSOM metadata file, which can contain an external
         definition of several of the relevant metadata fields accepted by this function.
@@ -323,6 +325,7 @@ def from_sssom(
         mapping_set_id=mapping_set_id,
         mapping_set_name=mapping_set_name,
         mapping_set_confidence=mapping_set_confidence,
+        mapping_set_version=mapping_set_version,
         license=license,
         justification=justification,
         version=version,

--- a/src/semra/io/io.py
+++ b/src/semra/io/io.py
@@ -498,16 +498,16 @@ def _parse_sssom_row(
             row["predicate_id"], standardize=standardize, name=row.get("predicate_label")
         )
         o = _from_curie(row["object_id"], standardize=standardize, name=row.get("object_label"))
-    except pydantic.ValidationError as e:
-        logger.warning("[%s] could not parse row: %s", index, e)
+    except pydantic.ValidationError as exc:
+        logger.warning("[%s] could not parse row: %s", index, exc)
         return None
-    e: dict[str, t.Any] = {
+    evidence_dict: dict[str, t.Any] = {
         "justification": justification,
         "mapping_set": mapping_set,
         "author": author,
         "confidence": confidence,
     }
-    return Mapping(s=s, p=p, o=o, evidence=[SimpleEvidence.model_validate(e)])
+    return Mapping(s=s, p=p, o=o, evidence=[SimpleEvidence.model_validate(evidence_dict)])
 
 
 def _from_curie(curie: str, *, standardize: bool, name: str | None = None) -> Reference:

--- a/src/semra/io/io.py
+++ b/src/semra/io/io.py
@@ -338,6 +338,7 @@ def from_sssom_df(
     mapping_set_id: str | None = None,
     mapping_set_name: str | None = None,
     mapping_set_confidence: float | None = None,
+    mapping_set_version: str | None = None,
     license: str | None = None,
     justification: Reference | None = None,
     version: str | None = None,
@@ -346,6 +347,18 @@ def from_sssom_df(
     _path: str | None = None,
 ) -> list[Mapping]:
     """Get mappings from a SSSOM dataframe."""
+    # deprecated
+    if version:
+        if mapping_set_version:
+            raise ValueError(
+                f"got both {version=} and {mapping_set_version=} when loading a SSSOM dataframe. Just use `mapping_set_version`"
+            )
+        else:
+            logger.warning(
+                "passing `version` when loading a SSSOM dataframe is deprecated. Use `mapping_set_version` instead"
+            )
+            mapping_set_version = version
+
     df = df.rename(
         columns={
             "source_id": "subject_id",
@@ -362,8 +375,10 @@ def from_sssom_df(
             mapping_set_name = metadata_dict.get("mapping_set_title")
         if mapping_set_id is None:
             mapping_set_id = metadata_dict.get("mapping_set_id")
-        if version is None:
-            version = metadata_dict.get("mapping_set_version")
+        if mapping_set_confidence is None:
+            mapping_set_confidence = metadata_dict.get("mapping_set_confidence")
+        if mapping_set_version is None:
+            mapping_set_version = metadata_dict.get("mapping_set_version")
         if license is None:
             license = metadata_dict.get("license")
 
@@ -381,8 +396,8 @@ def from_sssom_df(
             mapping_set_id=mapping_set_id,
             mapping_set_name=mapping_set_name,
             mapping_set_confidence=mapping_set_confidence,
+            mapping_set_version=mapping_set_version,
             license=license,
-            mapping_set_version=version,
             justification=justification,
             standardize=standardize,
             _path=_path,
@@ -406,9 +421,9 @@ def _parse_sssom_row(
     mapping_set_id: str | None,
     mapping_set_name: str | None,
     mapping_set_confidence: float | None,
+    mapping_set_version: str | None,
     license: str | None,
     justification: Reference | None,
-    mapping_set_version: str | None,
     standardize: bool,
     _path: str | None = None,
 ) -> Mapping | None:
@@ -464,8 +479,8 @@ def _parse_sssom_row(
         id=mapping_set_id,
         name=mapping_set_name,
         version=mapping_set_version,
-        license=license,
         confidence=mapping_set_confidence,
+        license=license,
     )
 
     if justification is not None:

--- a/src/semra/io/io.py
+++ b/src/semra/io/io.py
@@ -554,11 +554,11 @@ class SSSOMRow(NamedTuple):
 
 
 SSSOM_DEFAULT_COLUMNS = SSSOMRow._fields
-SSSOM_DUMMY_MAPPING_SET_BASE = "https://w3id.org/sssom/mappings/"
+FALLBACK_MAPPING_SET_ID_URI_PREFIX = "https://w3id.org/sssom/mappings/semra-"
 
 
 def _get_fallback_mapping_set_id() -> str:
-    return SSSOM_DUMMY_MAPPING_SET_BASE + str(uuid.uuid4())
+    return FALLBACK_MAPPING_SET_ID_URI_PREFIX + str(uuid.uuid4())
 
 
 def get_sssom_df(
@@ -620,7 +620,7 @@ def _get_sssom_row(mapping: Mapping, e: Evidence, fallback_mapping_set_id: str) 
     elif isinstance(e, ReasonedEvidence):
         # warning: SeMRA's format is not possible to capture in SSSOM
         mapping_set_id = fallback_mapping_set_id
-        mapping_set_name = f"semra-{fallback_mapping_set_id}"
+        mapping_set_name = "semra"
         mapping_set_version = ""
         mapping_set_license = ""
         mapping_set_confidence = "1.0"
@@ -713,25 +713,25 @@ def _write_sssom_stream(
 def _write_sssom_stream(
     mappings: Iterable[Mapping], file: str | Path | TextIO, *, stream: bool = False
 ) -> Generator[Mapping] | None:
-    dummy_id = _get_fallback_mapping_set_id()
+    fallback_mapping_set_id = _get_fallback_mapping_set_id()
     with safe_open_writer(file) as writer:
         writer.writerow(SSSOM_DEFAULT_COLUMNS)
         it = tqdm(mappings, desc="Writing SSSOM", leave=False, unit="mapping", unit_scale=True)
         if stream:
-            return _stream_write_sssom(writer, it, dummy_id)
+            return _stream_write_sssom(writer, it, fallback_mapping_set_id)
         else:
             for mapping in it:
                 for evidence in mapping.evidence:
-                    writer.writerow(_get_sssom_row(mapping, evidence, dummy_id))
+                    writer.writerow(_get_sssom_row(mapping, evidence, fallback_mapping_set_id))
             return None
 
 
 def _stream_write_sssom(
-    writer: Any, mappings: Iterable[Mapping], dummy_id: str
+    writer: Any, mappings: Iterable[Mapping], fallback_mapping_set_id: str
 ) -> Generator[Mapping]:
     for mapping in mappings:
         for evidence in mapping.evidence:
-            writer.writerow(_get_sssom_row(mapping, evidence, dummy_id))
+            writer.writerow(_get_sssom_row(mapping, evidence, fallback_mapping_set_id))
         yield mapping
 
 

--- a/src/semra/io/io.py
+++ b/src/semra/io/io.py
@@ -366,10 +366,13 @@ def from_sssom_df(
         columns={
             "source_id": "subject_id",
             "source_label": "subject_label",
+            "source_name": "subject_label",
             "target_id": "object_id",
             "target_label": "object_label",
+            "target_name": "object_label",
             "justification": "mapping_justification",
             "mapping_set_name": "mapping_set_title",
+            "mapping_set_license": "license",
         }
     )
     if metadata:

--- a/src/semra/rules.py
+++ b/src/semra/rules.py
@@ -71,6 +71,16 @@ INVERSION_MAPPING = _f(v.mapping_inversion)
 CHAIN_MAPPING = _f(v.mapping_chaining)
 KNOWLEDGE_MAPPING = _f(v.background_knowledge_based_matching_process)
 
+JUSTIFICATIONS = [
+    MANUAL_MAPPING,
+    LEXICAL_MAPPING,
+    UNSPECIFIED_MAPPING,
+    INVERSION_MAPPING,
+    CHAIN_MAPPING,
+    KNOWLEDGE_MAPPING,
+]
+CURIE_TO_JUSTIFICATION = {j.curie: j for j in JUSTIFICATIONS}
+
 charlie = _f(v.charlie)
 BEN_ORCID = Reference.from_curie("orcid:0000-0001-9439-5346", name="Benjamin M. Gyori")
 

--- a/src/semra/struct.py
+++ b/src/semra/struct.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import math
 import pickle
-import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from hashlib import md5
@@ -14,7 +13,6 @@ from typing import Annotated, Any, ClassVar, Generic, Literal, NamedTuple, Param
 import pydantic
 from more_itertools import triplewise
 from pydantic import ConfigDict, Field, model_validator
-from pydantic.types import UUID4
 from pyobo import Reference
 
 from semra.rules import SEMRA_EVIDENCE_PREFIX, SEMRA_MAPPING_PREFIX, SEMRA_MAPPING_SET_PREFIX
@@ -221,7 +219,6 @@ class SimpleEvidence(
             Reference(prefix="orcid", identifier="0000-0003-4423-4370"),
         ],
     )
-    uuid: UUID4 = Field(default_factory=uuid.uuid4)
     confidence: float | None = Field(None, description="The confidence")
 
     def _simple_key(self) -> SimpleEvidenceKey:

--- a/src/semra/struct.py
+++ b/src/semra/struct.py
@@ -142,7 +142,7 @@ class MappingSet(
     version: str | None = Field(
         default=None, description="The version of the dataset from which the mapping comes"
     )
-    license: str | None = Field(default=None, description="License name or URL for mapping set")
+    license: str | None = Field(default=None, description="License name or URL that applies to the whole mapping set")
     confidence: float = Field(..., description="Mapping set level confidence")
 
     def key(self) -> MappingSetKey:

--- a/src/semra/struct.py
+++ b/src/semra/struct.py
@@ -12,7 +12,7 @@ from typing import Annotated, Any, ClassVar, Generic, Literal, NamedTuple, Param
 
 import pydantic
 from more_itertools import triplewise
-from pydantic import ConfigDict, Field, model_validator
+from pydantic import ConfigDict, Field
 from pyobo import Reference
 
 from semra.rules import SEMRA_EVIDENCE_PREFIX, SEMRA_MAPPING_PREFIX, SEMRA_MAPPING_SET_PREFIX
@@ -155,24 +155,6 @@ class MappingSet(
         ...,
         description="Mapping set level confidence. This is _not_ a SSSOM field, since SeMRA makes a difference confidence assessment at the mapping set level and at the individual mapping level. This was requeted to be added to SSSOM in https://github.com/mapping-commons/sssom/issues/438.",
     )
-
-    id: str | None = Field(
-        default=None,
-        description="The identifier for the mapping set. Corresponds to required SSSOM field https://mapping-commons.github.io/sssom/mapping_set_id/.",
-    )
-
-    @model_validator(mode="before")
-    @classmethod
-    def ensure_default_id(cls, data: Any) -> Any:
-        """Add a missing ``mapping_set_id`` field, if missing in the ``id`` slot."""
-        if not isinstance(data, dict) or data.get("id"):
-            return data
-        name = data["name"].lower().replace(" ", "-").replace("_", "-")
-        identifier = f"https://w3id.org/sssom/mappings/{name}"
-        if version := data.get("version"):
-            identifier += f"v{version}"
-        data["id"] = identifier
-        return data
 
     def key(self) -> MappingSetKey:
         """Get a picklable key representing the mapping set."""

--- a/src/semra/struct.py
+++ b/src/semra/struct.py
@@ -142,7 +142,9 @@ class MappingSet(
     version: str | None = Field(
         default=None, description="The version of the dataset from which the mapping comes"
     )
-    license: str | None = Field(default=None, description="License name or URL that applies to the whole mapping set")
+    license: str | None = Field(
+        default=None, description="License name or URL that applies to the whole mapping set"
+    )
     confidence: float = Field(..., description="Mapping set level confidence")
 
     def key(self) -> MappingSetKey:

--- a/src/semra/struct.py
+++ b/src/semra/struct.py
@@ -166,7 +166,8 @@ class MappingSet(
         """Add a missing ``mapping_set_id`` field, if missing in the ``id`` slot."""
         if not isinstance(data, dict) or data.get("id"):
             return data
-        identifier = f"https://w3id.org/sssom/mappings/{data['name']}"
+        name = data["name"].lower().replace(" ", "-").replace("_", "-")
+        identifier = f"https://w3id.org/sssom/mappings/{name}"
         if version := data.get("version"):
             identifier += f"v{version}"
         data["id"] = identifier

--- a/src/semra/struct.py
+++ b/src/semra/struct.py
@@ -152,7 +152,7 @@ class MappingSet(
         description="License name or URL that applies to the whole mapping set. Corresponds to optional SSSOM field https://mapping-commons.github.io/sssom/license/",
     )
     confidence: float = Field(
-        ...,
+        default=1.0,
         description="Mapping set level confidence. This is _not_ a SSSOM field, since SeMRA makes a difference confidence assessment at the mapping set level and at the individual mapping level. This was requeted to be added to SSSOM in https://github.com/mapping-commons/sssom/issues/438.",
     )
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -302,7 +302,10 @@ class TestIO(unittest.TestCase):
 def _filter_simple(mappings: list[Mapping]) -> list[Mapping]:
     rv = []
     for mapping in mappings:
-        if all(isinstance(e, ReasonedEvidence) for e in mapping.evidence):
+        if all(
+            isinstance(e, ReasonedEvidence) or e.justification == CHAIN_MAPPING
+            for e in mapping.evidence
+        ):
             continue
         rv.append(mapping)
     return sorted(rv)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -266,7 +266,6 @@ class TestIO(unittest.TestCase):
 
     def test_sssom(self) -> None:
         """Test I/O with SSSOM."""
-        switch = False
         prefix_map = {
             "mesh": bioregistry.get_uri_prefix("mesh"),
             "orcid": bioregistry.get_uri_prefix("orcid"),
@@ -284,13 +283,15 @@ class TestIO(unittest.TestCase):
                 write_sssom(self.mappings, path, prune=prune)
                 new_mappings = assemble_evidences(from_sssom(path), progress=False)
 
-                if switch:
+                if not path.suffix.endswith(".gz"):
+                    # check gz after addressing https://github.com/mapping-commons/sssom-py/issues/581
                     msdf = sssom.io.parse_sssom_table(path, prefix_map=prefix_map)
                     for vt in DEFAULT_VALIDATION_TYPES:
                         with self.subTest(msg=f"SSSOM Validation: {vt.name}"):
                             report = VALIDATION_METHODS[vt](msdf, False)
-                            self.assertIsNotNone(report)
-                            self.assertEqual([], report.results)
+                            if report is not None:
+                                # requires https://github.com/mapping-commons/sssom-py/pull/579
+                                self.assertEqual([], report.results)
 
                 with self.subTest(msg="reconstitution"):
                     # TODO update to also work for reasoned?

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -15,8 +15,11 @@ from semra.io import (
     from_multidigraph,
     from_pyobo,
     from_sssom_df,
+    from_sssom,
+    write_sssom,
     to_digraph,
     to_multidigraph,
+    from_pickle, write_pickle,
     write_jsonl,
 )
 from semra.rules import (
@@ -249,3 +252,25 @@ class TestIO(unittest.TestCase):
         self.assertEqual(
             sorted(self.mappings), sorted(from_multidigraph(to_multidigraph(self.mappings)))
         )
+
+    def test_pickle(self) -> None:
+        """Test I/O with pickle."""
+        with tempfile.TemporaryDirectory() as directory_:
+            for path in [
+                Path(directory_).joinpath("test.pkl"),
+                Path(directory_).joinpath("test.pkl.gz"),
+            ]:
+                write_pickle(self.mappings, path)
+                new_mappings = from_pickle(path)
+                self.assertEqual(self.mappings, new_mappings)
+
+    def test_sssom(self) -> None:
+        """Test I/O with SSSOM."""
+        with tempfile.TemporaryDirectory() as directory_:
+            for path in [
+                Path(directory_).joinpath("test.sssom.tsv"),
+                Path(directory_).joinpath("test.sssom.tsv.gz"),
+            ]:
+                write_sssom(self.mappings, path)
+                new_mappings = from_sssom(path)
+                self.assertEqual(sorted(self.mappings), sorted(new_mappings))

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -49,7 +49,6 @@ mapping_set_confidence = 0.6
 class TestIOLocal(unittest.TestCase):
     """Test I/O functions that only run if pyobo is available."""
 
-    @unittest.skip
     def test_from_pyobo(self) -> None:
         """Test loading content from PyOBO."""
         mappings = from_pyobo("doid")
@@ -298,7 +297,7 @@ class TestIO(unittest.TestCase):
                     self.assertEqual(_filter_simple(self.mappings), _filter_simple(new_mappings))
 
 
-def _filter_simple(mappings: list[Mapping]):
+def _filter_simple(mappings: list[Mapping]) -> list[Mapping]:
     rv = []
     for mapping in mappings:
         if all(isinstance(e, ReasonedEvidence) for e in mapping.evidence):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -13,14 +13,15 @@ from semra.io import (
     from_digraph,
     from_jsonl,
     from_multidigraph,
+    from_pickle,
     from_pyobo,
-    from_sssom_df,
     from_sssom,
-    write_sssom,
+    from_sssom_df,
     to_digraph,
     to_multidigraph,
-    from_pickle, write_pickle,
     write_jsonl,
+    write_pickle,
+    write_sssom,
 )
 from semra.rules import (
     BEN_ORCID,

--- a/tox.ini
+++ b/tox.ini
@@ -115,6 +115,7 @@ deps =
     pydantic
     types-requests
     types-tabulate
+    types-PyYAML
 extras =
     web
 commands = mypy --ignore-missing-imports --strict src/ tests/


### PR DESCRIPTION
Related to #60

This PR does the following:

1. Makes SSSOM output much more detailed, cleans up some incorrect column names
   - make sure outputs use `mapping_set_title` and not `mapping_set_name`
   - outputs _something_ for `mapping_set_id`, can improve this in a future PR
2. Extends past what's in SSSOM standard
   - Makes more clear the delineation between mapping-level confidence and mapping set-level confidence. Suggested for addition to SSSOM in https://github.com/mapping-commons/sssom/
issues/438
   - Make mapping set confidence default to 1.0 in the SeMRA data model so it's not required to pass it from high-level functions, like `sssom.io.from_sssom()`
4. Updates README


## future work

field ideas:

- Add `triple_id`, which is the hash of the s-p-o triple for a mapping
- Add `reasoned` which is a pipe-separated list of triples that are used as evidence for a reasoned evidence
- Add a mapping set ID that's optional
