### PR TITLE
Fully stream database build

### DIFF
--- a/src/semra/database.py
+++ b/src/semra/database.py
@@ -21,13 +21,7 @@ from tqdm.contrib.logging import logging_redirect_tqdm
 from zenodo_client import Creator, Metadata, ensure_zenodo
 
 from semra import Mapping
-from semra.io import (
-    from_jsonl,
-    from_pyobo,
-    write_jsonl,
-    write_neo4j,
-    write_sssom,
-)
+from semra.io import from_jsonl, from_pyobo, write_jsonl, write_neo4j, write_sssom
 from semra.io.io_utils import safe_open_writer
 from semra.pipeline import REFRESH_SOURCE_OPTION, UPLOAD_OPTION
 from semra.sources import SOURCE_RESOLVER
@@ -416,10 +410,6 @@ def _write_source(
 
 def _get_sssom_path(subdirectory: str, key: str) -> Path:
     return SOURCES.join(subdirectory, name=f"{key}.sssom.tsv.gz")
-
-
-def _get_pickle_path(subdirectory: str, key: str) -> Path:
-    return SOURCES.join(subdirectory, name=f"{key}.pkl.gz")
 
 
 def _get_jsonl_path(subdirectory: str, key: str) -> Path:

--- a/src/semra/database.py
+++ b/src/semra/database.py
@@ -103,7 +103,6 @@ skip_pyobo = {
     is_flag=True,
     help="If true, will try and prune unused SSSOM columns during output",
 )
-@click.option("--format", type=click.Choice(["jsonl", "sssom", "neo4j"]), default="neo4j")
 @UPLOAD_OPTION
 @REFRESH_SOURCE_OPTION
 def build(
@@ -112,7 +111,6 @@ def build(
     refresh_source: bool,
     write_labels: bool,
     prune_sssom: bool,
-    format: str,
 ) -> None:
     """Construct the full SeMRA database."""
     ontology_resources: list[bioregistry.Resource] = []

--- a/src/semra/database.py
+++ b/src/semra/database.py
@@ -5,7 +5,7 @@ import time
 from collections.abc import Iterable
 from operator import attrgetter
 from pathlib import Path
-from typing import NamedTuple
+from typing import Literal, NamedTuple, overload
 
 import bioregistry
 import click
@@ -22,11 +22,10 @@ from zenodo_client import Creator, Metadata, ensure_zenodo
 
 from semra import Mapping
 from semra.io import (
-    from_pickle,
+    from_jsonl,
     from_pyobo,
     write_jsonl,
     write_neo4j,
-    write_pickle,
     write_sssom,
 )
 from semra.io.io_utils import safe_open_writer
@@ -104,6 +103,7 @@ skip_pyobo = {
     is_flag=True,
     help="If true, will try and prune unused SSSOM columns during output",
 )
+@click.option("--format", type=click.Choice(["jsonl", "sssom", "neo4j"]), default="neo4j")
 @UPLOAD_OPTION
 @REFRESH_SOURCE_OPTION
 def build(
@@ -112,6 +112,7 @@ def build(
     refresh_source: bool,
     write_labels: bool,
     prune_sssom: bool,
+    format: str,
 ) -> None:
     """Construct the full SeMRA database."""
     ontology_resources: list[bioregistry.Resource] = []
@@ -131,25 +132,16 @@ def build(
         elif resource.get_obofoundry_prefix() or resource.has_download():
             ontology_resources.append(resource)
 
-    mappings: list[Mapping] = []
-    mappings.extend(
-        _yield_ontology_resources(
-            ontology_resources, refresh_source=refresh_source, write_labels=write_labels
-        )
+    mappings = _yield_mappings(
+        ontology_resources,
+        pyobo_resources,
+        refresh_source,
+        write_labels,
+        include_wikidata=include_wikidata,
     )
-    mappings.extend(
-        _yield_pyobo(pyobo_resources, refresh_source=refresh_source, write_labels=write_labels)
-    )
-    mappings.extend(_yield_custom(write_labels=write_labels))
-
-    if include_wikidata:
-        mappings.extend(_yield_wikidata(write_labels=write_labels))
-
-    click.echo(f"Writing JSONL to {JSONL_PATH}")
-    write_jsonl(mappings, JSONL_PATH)
-    click.echo(f"Writing SSSOM to {SSSOM_PATH}")
-    write_sssom(mappings, SSSOM_PATH, add_labels=False, prune=False)
-    click.echo(f"Writing Neo4j folder to {NEO4J_DIR}")
+    mappings = write_jsonl(mappings, JSONL_PATH, stream=True)
+    mappings = write_sssom(mappings, SSSOM_PATH, add_labels=False, prune=False, stream=True)
+    # neo4j doesn't need to stream since it's last
     write_neo4j(mappings, NEO4J_DIR)
 
     if upload:
@@ -179,6 +171,24 @@ def build(
         click.echo(res.json()["links"]["html"])
 
 
+def _yield_mappings(
+    ontology_resources: list[bioregistry.Resource],
+    pyobo_resources: list[bioregistry.Resource],
+    refresh_source: bool,
+    write_labels: bool,
+    include_wikidata: bool,
+) -> Iterable[Mapping]:
+    yield from _yield_ontology_resources(
+        ontology_resources, refresh_source=refresh_source, write_labels=write_labels
+    )
+    yield from _yield_pyobo(
+        pyobo_resources, refresh_source=refresh_source, write_labels=write_labels
+    )
+    yield from _yield_custom(write_labels=write_labels)
+    if include_wikidata:
+        yield from _yield_wikidata(write_labels=write_labels)
+
+
 def _yield_custom(*, write_labels: bool) -> Iterable[Mapping]:
     click.secho("\nCustom SeMRA Sources", fg="cyan", bold=True)
     funcs = tqdm(
@@ -189,25 +199,31 @@ def _yield_custom(*, write_labels: bool) -> Iterable[Mapping]:
         if resource_name == "wikidata":
             # this one needs extra informatzi
             continue
-        pickle_gz_path = _get_pickle_path("custom", resource_name)
+
+        tqdm.write(click.style("\n" + resource_name, fg="green"))
+        funcs.set_postfix(source=resource_name)
+
         start = time.time()
-        if pickle_gz_path.is_file():
-            resource_mappings = from_pickle(pickle_gz_path)
-            tqdm.write(
-                f"loaded {len(resource_mappings):,} from cache at {pickle_gz_path} in {time.time() - start:.2f} seconds"
-            )
+        count = 0
+        if (jsonl_path := _get_jsonl_path("custom", resource_name)).is_file():
+            for mapping in from_jsonl(jsonl_path, stream=True):
+                count += 1
+                yield mapping
         else:
-            tqdm.write(click.style("\n" + resource_name, fg="green"))
-            funcs.set_postfix(source=resource_name)
             with logging_redirect_tqdm():
                 resource_mappings = func()
-                _write_source(resource_mappings, "custom", resource_name, write_labels=write_labels)
+                for mapping in _write_source(
+                    resource_mappings,
+                    "custom",
+                    resource_name,
+                    write_labels=write_labels,
+                    stream=True,
+                ):
+                    count += 1
+                    yield mapping
 
-        summaries.append(
-            SummaryRow(resource_name, len(resource_mappings), time.time() - start, "custom")
-        )
+        summaries.append(SummaryRow(resource_name, count, time.time() - start, "custom"))
         _write_summary()
-        yield from resource_mappings
 
 
 def _yield_pyobo(
@@ -218,31 +234,37 @@ def _yield_pyobo(
     for resource in it:
         if resource.prefix in skip_pyobo:
             continue
+
         tqdm.write(click.style("\n" + resource.prefix, fg="green"))
         it.set_postfix(prefix=resource.prefix)
-        pickle_gz_path = _get_pickle_path("pyobo", resource.prefix)
+
         start = time.time()
-        if pickle_gz_path.is_file():
-            resource_mappings = from_pickle(pickle_gz_path)
-            tqdm.write(
-                f"loaded {len(resource_mappings):,} from cache at {pickle_gz_path} in {time.time() - start:.2f} seconds"
-            )
+        count = 0
+        if (jsonl_path := _get_jsonl_path("pyobo", resource.prefix)).is_file():
+            for mapping in from_jsonl(jsonl_path, stream=True):
+                count += 1
+                yield mapping
         else:
             try:
                 with logging_redirect_tqdm():
                     resource_mappings = from_pyobo(
                         resource.prefix, force_process=refresh_source, cache=False
                     )
+                    for mapping in _write_source(
+                        resource_mappings,
+                        "pyobo",
+                        resource.prefix,
+                        write_labels=write_labels,
+                        stream=True,
+                    ):
+                        count += 1
+                        yield mapping
             except Exception as e:
-                tqdm.write(f"failed PyOBO parsing on {resource.prefix}: {e}")
+                tqdm.write(f"[{resource.prefix}] failed PyOBO parsing: {e}")
                 continue
-            _write_source(resource_mappings, "pyobo", resource.prefix, write_labels=write_labels)
 
-        summaries.append(
-            SummaryRow(resource.prefix, len(resource_mappings), time.time() - start, "pyobo")
-        )
+        summaries.append(SummaryRow(resource.prefix, count, time.time() - start, "pyobo"))
         _write_summary()
-        yield from resource_mappings
 
 
 def _yield_wikidata(*, write_labels: bool) -> Iterable[Mapping]:
@@ -253,29 +275,31 @@ def _yield_wikidata(*, write_labels: bool) -> Iterable[Mapping]:
     for prefix, wikidata_property in wikidata_prefix_it:
         if prefix in skip_wikidata_prefixes:
             continue
+
         wikidata_prefix_it.set_postfix(prefix=prefix)
         tqdm.write(click.style(f"\n{prefix} ({wikidata_property})", fg="green"))
         resource_name = f"wikidata_{prefix}"
-        pickle_gz_path = _get_pickle_path("wikidata", resource_name)
+
         start = time.time()
-        if pickle_gz_path.is_file():
-            resource_mappings = from_pickle(pickle_gz_path)
-            tqdm.write(
-                f"loaded {len(resource_mappings):,} from cache at {pickle_gz_path} in {time.time() - start:.2f} seconds"
-            )
+        count = 0
+        if (jsonl_path := _get_jsonl_path("wikidata", resource_name)).is_file():
+            for mapping in from_jsonl(jsonl_path, stream=True):
+                count += 1
+                yield mapping
         else:
             try:
                 resource_mappings = get_wikidata_mappings_by_prefix(prefix)
+                for mapping in _write_source(
+                    resource_mappings, "wikidata", resource_name, write_labels=write_labels
+                ):
+                    count += 1
+                    yield mapping
             except requests.exceptions.JSONDecodeError as e:
                 tqdm.write(f"[{resource_name}] failed to get mappings from wikidata: {e}")
                 continue
-            _write_source(resource_mappings, "wikidata", resource_name, write_labels=write_labels)
 
-        summaries.append(
-            SummaryRow(resource_name, len(resource_mappings), time.time() - start, "wikidata")
-        )
+        summaries.append(SummaryRow(resource_name, count, time.time() - start, "wikidata"))
         _write_summary()
-        yield from resource_mappings
 
 
 def _yield_ontology_resources(
@@ -290,13 +314,13 @@ def _yield_ontology_resources(
     for resource in it:
         it.set_postfix(prefix=resource.prefix)
         tqdm.write(click.style("\n" + resource.prefix, fg="green"))
-        pickle_gz_path = _get_pickle_path("ontology", resource.prefix)
+
         start = time.time()
-        if pickle_gz_path.is_file():
-            resource_mappings = from_pickle(pickle_gz_path)
-            tqdm.write(
-                f"loaded {len(resource_mappings):,} from cache at {pickle_gz_path} in {time.time() - start:.2f} seconds"
-            )
+        count = 0
+        if (jsonl_path := _get_jsonl_path("ontology", resource.prefix)).is_file():
+            for mapping in from_jsonl(jsonl_path, stream=True):
+                count += 1
+                yield mapping
         else:
             try:
                 with logging_redirect_tqdm():
@@ -306,36 +330,89 @@ def _yield_ontology_resources(
             except (ValueError, NoBuildError, subprocess.SubprocessError) as e:
                 tqdm.write(f"[{resource.prefix}] failed ontology parsing: {e}")
                 continue
-            _write_source(resource_mappings, "ontology", resource.prefix, write_labels=write_labels)
+            else:
+                for mapping in _write_source(
+                    resource_mappings,
+                    "ontology",
+                    resource.prefix,
+                    write_labels=write_labels,
+                    stream=True,
+                ):
+                    count += 1
+                    yield mapping
             # this outputs on each iteration to get faster insight
             write_warned(WARNINGS_PATH)
             write_getter_warnings(ERRORS_PATH)
 
-        summaries.append(
-            SummaryRow(resource.prefix, len(resource_mappings), time.time() - start, "pyobo")
-        )
+        summaries.append(SummaryRow(resource.prefix, count, time.time() - start, "ontology"))
         _write_summary()
-        yield from resource_mappings
 
 
-def _write_source(mappings: list[Mapping], subdirectory: str, key: str, write_labels: bool) -> None:
-    write_pickle(mappings, _get_pickle_path(subdirectory, key))
-    write_sssom(
-        mappings,
-        SOURCES.join(subdirectory, name=f"{key}.sssom.tsv.gz"),
-        add_labels=write_labels,
-    )
-    if mappings:
-        tqdm.write(f"produced {len(mappings):,} mappings")
+@overload
+def _write_source(
+    mappings: list[Mapping],
+    subdirectory: str,
+    key: str,
+    write_labels: bool,
+    stream: Literal[True] = True,
+) -> Iterable[Mapping]: ...
+
+
+@overload
+def _write_source(
+    mappings: list[Mapping],
+    subdirectory: str,
+    key: str,
+    write_labels: bool,
+    stream: Literal[False] = False,
+) -> None: ...
+
+
+def _write_source(
+    mappings: Iterable[Mapping],
+    subdirectory: str,
+    key: str,
+    write_labels: bool,
+    stream: bool = False,
+) -> None | Iterable[Mapping]:
+    jsonl_path = _get_jsonl_path(subdirectory, key)
+    sssom_path = _get_sssom_path(subdirectory, key)
+    if stream:
+        mappings = write_jsonl(mappings, jsonl_path, stream=True)
+        mappings = write_sssom(
+            mappings, sssom_path, add_labels=write_labels, prune=False, stream=True
+        )
+        count = 0
+        for mapping in mappings:
+            yield mapping
+            count += 1
+    else:
+        mappings = list(mappings)
+        write_jsonl(mappings, jsonl_path, stream=False)
+        write_sssom(mappings, sssom_path, add_labels=write_labels, prune=False, stream=False)
+        count = len(mappings)
+
+    if count:
+        tqdm.write(f"produced {count:,} mappings")
     else:
         tqdm.write("produced no mappings")
         SOURCES.join(subdirectory, name=f"{key}.empty.txt").write_text("")
         EMPTY.append(key)
         EMPTY_PATH.write_text("\n".join(EMPTY))
 
+    return None
+
+
+def _get_sssom_path(subdirectory: str, key: str) -> Path:
+    return SOURCES.join(subdirectory, name=f"{key}.sssom.tsv.gz")
+
 
 def _get_pickle_path(subdirectory: str, key: str) -> Path:
     return SOURCES.join(subdirectory, name=f"{key}.pkl.gz")
+
+
+def _get_jsonl_path(subdirectory: str, key: str) -> Path:
+    return SOURCES.join(subdirectory, name=f"{key}.jsonl.gz")
 
 
 def _write_summary() -> None:

--- a/src/semra/io/io.py
+++ b/src/semra/io/io.py
@@ -493,6 +493,7 @@ def _get_sssom_row(mapping: Mapping, e: Evidence) -> tuple[str, ...]:
     )
 
 
+# docstr-coverage:excused `overload`
 @overload
 def write_sssom(
     mappings: Iterable[Mapping],
@@ -504,6 +505,7 @@ def write_sssom(
 ) -> Generator[Mapping]: ...
 
 
+# docstr-coverage:excused `overload`
 @overload
 def write_sssom(
     mappings: Iterable[Mapping],
@@ -537,12 +539,14 @@ def write_sssom(
         return None
 
 
+# docstr-coverage:excused `overload`
 @overload
 def _write_sssom_stream(
     mappings: Iterable[Mapping], file: str | Path | TextIO, *, stream: Literal[False] = False
 ) -> None: ...
 
 
+# docstr-coverage:excused `overload`
 @overload
 def _write_sssom_stream(
     mappings: Iterable[Mapping], file: str | Path | TextIO, *, stream: Literal[True] = True
@@ -593,6 +597,7 @@ def from_pickle(path: str | Path) -> list[Mapping]:
             return cast(list[Mapping], pickle.load(file))
 
 
+# docstr-coverage:excused `overload`
 @overload
 def write_jsonl(
     objects: Iterable[X],
@@ -603,6 +608,7 @@ def write_jsonl(
 ) -> None: ...
 
 
+# docstr-coverage:excused `overload`
 @overload
 def write_jsonl(
     objects: Iterable[X],
@@ -640,12 +646,14 @@ def _stream_write_jsonl(models: Iterable[X], file: TextIO) -> Generator[X]:
         yield model
 
 
+# docstr-coverage:excused `overload`
 @overload
 def from_jsonl(
     path: str | Path, *, show_progress: bool = ..., stream: Literal[False] = False
 ) -> list[Mapping]: ...
 
 
+# docstr-coverage:excused `overload`
 @overload
 def from_jsonl(
     path: str | Path, *, show_progress: bool = ..., stream: Literal[True] = True

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -238,6 +238,7 @@ class TestIO(unittest.TestCase):
             ]:
                 write_jsonl(self.mappings, path)
                 new_mappings = from_jsonl(path, show_progress=False)
+                self.assertIsInstance(new_mappings, list)
                 self.assertEqual(self.mappings, new_mappings)
 
     def test_digraph(self) -> None:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -81,7 +81,8 @@ class TestPipeline(unittest.TestCase):
         """Test using SSSOM sources in the configuration."""
         with tempfile.TemporaryDirectory() as d:
             path = Path(d).resolve().joinpath("test.sssom.tsv")
-            write_sssom(TEST_MAPPINGS, path)
+            res = write_sssom(TEST_MAPPINGS, path)
+            self.assertIsNone(res, msg="streaming should not be activated")
 
             inp = Input(source="sssom", prefix=path.as_posix(), extras={"mapping_set_name": "test"})
             config = Configuration(


### PR DESCRIPTION
- refactors database build to only stream files from jsonl instead of pickle. The jsonl gzipped files are only a tiny big bigger thank pickle gzipped files, so this is a nice tradeoff
- adds a `stream: bool` argument to many writing functions so several can be chained while only consuming a single iterable