### PR TITLE
Rename fields in mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ r1 = Reference(prefix="chebi", identifier="107635", name="2,3-diacetyloxybenzoic
 r2 = Reference(prefix="mesh", identifier="C011748", name="tosiben")
 
 mapping = Mapping(
-   s=r1, p=EXACT_MATCH, o=r2,
+   subject=r1, predicate=EXACT_MATCH, object=r2,
    evidence=[
       SimpleEvidence(
          justification=MANUAL_MAPPING,
@@ -119,7 +119,7 @@ from semra.inference import infer_reversible
 r1 = Reference(prefix="chebi", identifier="107635", name="2,3-diacetyloxybenzoic")
 r2 = Reference(prefix="mesh", identifier="C011748", name="tosiben")
 
-mapping = Mapping(s=r1, p=EXACT_MATCH, o=r2)
+mapping = Mapping(subject=r1, predicate=EXACT_MATCH, object=r2)
 
 # includes the mesh -> exact match-> chebi mapping with full provenance
 mappings = infer_reversible([mapping])
@@ -144,8 +144,8 @@ r1 = Reference.from_curie("mesh:C406527", name="R 115866")
 r2 = Reference.from_curie("chebi:101854", name="talarozole")
 r3 = Reference.from_curie("chembl.compound:CHEMBL459505", name="TALAROZOLE")
 
-m1 = Mapping(s=r1, p=EXACT_MATCH, o=r2)
-m2 = Mapping(s=r2, p=EXACT_MATCH, o=r3)
+m1 = Mapping(subject=r1, predicate=EXACT_MATCH, object=r2)
+m2 = Mapping(subject=r2, predicate=EXACT_MATCH, object=r3)
 
 # infers r1 -> exact match -> r3
 mappings = infer_chains([m1, m2])
@@ -170,7 +170,7 @@ from semra.inference import infer_generalizations
 r1 = Reference.from_curie("chebi:101854", name="talarozole")
 r2 = Reference.from_curie("chembl.compound:CHEMBL459505", name="TALAROZOLE")
 
-m1 = Mapping(s=r1, p=EXACT_MATCH, o=r2)
+m1 = Mapping(subject=r1, predicate=EXACT_MATCH, object=r2)
 
 mappings = infer_generalizations([m1])
 ```
@@ -192,7 +192,7 @@ from semra.inference import infer_dbxref_mutations
 
 r1 = Reference.from_curie("doid:0050577", name="cranioectodermal dysplasia")
 r2 = Reference.from_curie("mesh:C562966", name="Cranioectodermal Dysplasia")
-m1 = Mapping(s=r1, p=DB_XREF, o=r2)
+m1 = Mapping(subject=r1, predicate=DB_XREF, object=r2)
 
 # we're 99% confident doid-mesh dbxrefs actually are exact matches
 mappings = infer_dbxref_mutations([m1], {("doid", "mesh"): 0.99})

--- a/src/semra/client.py
+++ b/src/semra/client.py
@@ -181,9 +181,9 @@ class Neo4jClient:
             )
             evidence.append(pydantic.parse_obj_as(Evidence, evidence_dict))  # type:ignore
         return semra.Mapping(
-            s=Reference.from_curie(source_curie),
-            p=Reference.from_curie(mapping["predicate"]),
-            o=Reference.from_curie(target_curie),
+            subject=Reference.from_curie(source_curie),
+            predicate=Reference.from_curie(mapping["predicate"]),
+            object=Reference.from_curie(target_curie),
             evidence=evidence,
         )
 

--- a/src/semra/gilda_utils.py
+++ b/src/semra/gilda_utils.py
@@ -90,10 +90,11 @@ def update_terms(terms: list[gilda.Term], mappings: list[Mapping]) -> list[gilda
         terms_index[term.db, term.id].append(term)
 
     for mapping in tqdm(mappings, unit="mapping", unit_scale=True, desc="applying mappings"):
-        source_terms = terms_index.pop(mapping.s.pair, None)
+        source_terms = terms_index.pop(mapping.subject.pair, None)
         if source_terms:
-            terms_index[mapping.o.pair].extend(
-                make_new_term(term, mapping.o.prefix, mapping.o.identifier) for term in source_terms
+            terms_index[mapping.object.pair].extend(
+                make_new_term(term, mapping.object.prefix, mapping.object.identifier)
+                for term in source_terms
             )
 
     # Unwind the terms index

--- a/src/semra/io/graph.py
+++ b/src/semra/io/graph.py
@@ -50,7 +50,7 @@ def to_digraph(mappings: t.Iterable[Mapping]) -> nx.DiGraph:
         defaultdict(lambda: defaultdict(list))
     )
     for mapping in mappings:
-        edges[mapping.s, mapping.o][mapping.p].extend(mapping.evidence)
+        edges[mapping.subject, mapping.object][mapping.predicate].extend(mapping.evidence)
     for (s, o), data in edges.items():
         graph.add_edge(s, o, **{DIGRAPH_DATA_KEY: data})
     return graph
@@ -64,7 +64,7 @@ def from_digraph(graph: nx.DiGraph) -> list[Mapping]:
 def _from_digraph_edge(graph: nx.Graph, s: Reference, o: Reference) -> t.Iterable[Mapping]:
     data = graph[s][o]
     for p, evidence in data[DIGRAPH_DATA_KEY].items():
-        yield Mapping(s=s, p=p, o=o, evidence=evidence)
+        yield Mapping(subject=s, predicate=p, object=o, evidence=evidence)
 
 
 def to_multidigraph(mappings: t.Iterable[Mapping], *, progress: bool = False) -> nx.MultiDiGraph:
@@ -86,9 +86,9 @@ def to_multidigraph(mappings: t.Iterable[Mapping], *, progress: bool = False) ->
     graph = nx.MultiDiGraph()
     for mapping in semra_tqdm(mappings, progress=progress):
         graph.add_edge(
-            mapping.s,
-            mapping.o,
-            key=mapping.p,
+            mapping.subject,
+            mapping.object,
+            key=mapping.predicate,
             **{MULTIDIGRAPH_DATA_KEY: mapping.evidence},
         )
     return graph
@@ -97,6 +97,6 @@ def to_multidigraph(mappings: t.Iterable[Mapping], *, progress: bool = False) ->
 def from_multidigraph(graph: nx.MultiDiGraph) -> list[Mapping]:
     """Extract mappings from a multi-directed graph data model."""
     return [
-        Mapping(s=s, p=p, o=o, evidence=data[MULTIDIGRAPH_DATA_KEY])
+        Mapping(subject=s, predicate=p, object=o, evidence=data[MULTIDIGRAPH_DATA_KEY])
         for s, o, p, data in graph.edges(keys=True, data=True)
     ]

--- a/src/semra/io/neo4j_io.py
+++ b/src/semra/io/neo4j_io.py
@@ -217,24 +217,24 @@ def write_neo4j(
         ):
             mapping_curie = mapping.curie
 
-            if mapping.s not in seen_concepts:
+            if mapping.subject not in seen_concepts:
                 concept_nodes_writer.writerow(
-                    _concept_to_row(mapping.s, add_labels, equivalence_classes)
+                    _concept_to_row(mapping.subject, add_labels, equivalence_classes)
                 )
-                seen_concepts.add(mapping.s)
-            if mapping.o not in seen_concepts:
+                seen_concepts.add(mapping.subject)
+            if mapping.object not in seen_concepts:
                 concept_nodes_writer.writerow(
-                    _concept_to_row(mapping.o, add_labels, equivalence_classes)
+                    _concept_to_row(mapping.object, add_labels, equivalence_classes)
                 )
-                seen_concepts.add(mapping.o)
+                seen_concepts.add(mapping.object)
 
             mapping_nodes_writer.writerow(_mapping_to_node_row(mapping_curie, mapping))
             mapping_edges_writer.writerow(_mapping_to_edge_row(mapping))
 
             # these connect the node representing the mappings to the
             # subject and object using the RDF reified edge data model
-            edge_writer.writerow((mapping_curie, ANNOTATED_SOURCE_CURIE, mapping.s.curie))
-            edge_writer.writerow((mapping_curie, ANNOTATED_TARGET_CURIE, mapping.o.curie))
+            edge_writer.writerow((mapping_curie, ANNOTATED_SOURCE_CURIE, mapping.subject.curie))
+            edge_writer.writerow((mapping_curie, ANNOTATED_TARGET_CURIE, mapping.object.curie))
 
             for evidence in mapping.evidence:
                 evidence_curie = evidence.get_reference(mapping).curie
@@ -330,7 +330,7 @@ def _mapping_to_node_row(mapping_curie: str, mapping: Mapping) -> Sequence[str]:
     return (
         mapping_curie,
         SEMRA_MAPPING_PREFIX,
-        mapping.p.curie,
+        mapping.predicate.curie,
         get_confidence_str(mapping),
         _neo4j_bool(mapping.has_primary),
         _neo4j_bool(mapping.has_secondary),
@@ -350,9 +350,9 @@ def _evidence_to_row(evidence_curie: str, evidence: Evidence) -> Sequence[str]:
 
 def _mapping_to_edge_row(mapping: Mapping) -> Sequence[str]:
     return (
-        mapping.s.curie,
-        mapping.p.curie,
-        mapping.o.curie,
+        mapping.subject.curie,
+        mapping.predicate.curie,
+        mapping.object.curie,
         get_confidence_str(mapping),
         _neo4j_bool(mapping.has_primary),
         _neo4j_bool(mapping.has_secondary),

--- a/src/semra/landscape/utils.py
+++ b/src/semra/landscape/utils.py
@@ -582,7 +582,7 @@ def get_observed_terms(mappings: t.Iterable[Mapping]) -> dict[str, set[str]]:
     """Get the set of terms appearing in each prefix."""
     entities: defaultdict[str, set[str]] = defaultdict(set)
     for mapping in mappings:
-        for reference in (mapping.s, mapping.o):
+        for reference in (mapping.subject, mapping.object):
             entities[reference.prefix].add(reference.identifier)
     return dict(entities)
 

--- a/src/semra/pipeline.py
+++ b/src/semra/pipeline.py
@@ -533,11 +533,11 @@ def get_mappings_from_config(
 def _get_equivalence_classes(
     mappings: Iterable[Mapping], prioritized_mappings: Iterable[Mapping]
 ) -> dict[Reference, bool]:
-    priority_references = {mapping.o for mapping in prioritized_mappings}
+    priority_references = {mapping.object for mapping in prioritized_mappings}
     rv = {}
     for mapping in mappings:
-        rv[mapping.s] = mapping.s in priority_references
-        rv[mapping.o] = mapping.o in priority_references
+        rv[mapping.subject] = mapping.subject in priority_references
+        rv[mapping.object] = mapping.object in priority_references
     return rv
 
 
@@ -670,7 +670,7 @@ def process(
         logger.info("Removing unqualified database xrefs")
         before = len(mappings)
         start = time.time()
-        mappings = [m for m in mappings if m.p not in IMPRECISE]
+        mappings = [m for m in mappings if m.predicate not in IMPRECISE]
         _log_diff(before, mappings, verb="Filtered non-precise", elapsed=time.time() - start)
 
     # 3. Inference based on adding reverse relations then doing multichain hopping

--- a/src/semra/sources/biopragmatics.py
+++ b/src/semra/sources/biopragmatics.py
@@ -96,9 +96,9 @@ def _process(mapping_dicts: Iterable[dict[str, Any]], confidence: float = 0.999)
             predicate = Reference(prefix="skos", identifier="exactMatch", name="exact match")
 
         mm = Mapping(
-            s=subject,
-            p=predicate,
-            o=obj,
+            subject=subject,
+            predicate=predicate,
+            object=obj,
             evidence=[
                 SimpleEvidence(
                     justification=Reference.from_curie(mapping_dict["type"]),

--- a/src/semra/sources/cbms2019.py
+++ b/src/semra/sources/cbms2019.py
@@ -44,14 +44,14 @@ def _get_doid(url: str) -> list[Mapping]:
     )
     for do_id, target_prefix, target_id in df.values:
         try:
-            o = Reference(prefix=NSM[target_prefix], identifier=target_id)
+            obj = Reference(prefix=NSM[target_prefix], identifier=target_id)
         except ValidationError:
             tqdm.write(f"[doid:{do_id}] failed to parse xref {target_prefix}:{target_id}")
             continue
         mapping = Mapping(
-            s=Reference(prefix="doid", identifier=do_id.removeprefix("DOID:")),
-            p=EXACT_MATCH,
-            o=o,
+            subject=Reference(prefix="doid", identifier=do_id.removeprefix("DOID:")),
+            predicate=EXACT_MATCH,
+            object=obj,
             evidence=[evidence],
         )
         rv.append(mapping)
@@ -71,9 +71,9 @@ def _get_mesh_to_icd_via_snomedct() -> list[Mapping]:
         mesh_ref = Reference(prefix="mesh", identifier=mesh_id)
         rows.append(
             Mapping(
-                s=mesh_ref,
-                p=EXACT_MATCH,
-                o=snomed_ref,
+                subject=mesh_ref,
+                predicate=EXACT_MATCH,
+                object=snomed_ref,
                 evidence=[
                     SimpleEvidence(
                         mapping_set=MappingSet(
@@ -94,9 +94,9 @@ def _get_mesh_to_icd_via_snomedct() -> list[Mapping]:
         else:
             rows.append(
                 Mapping(
-                    s=mesh_ref,
-                    p=EXACT_MATCH,
-                    o=icd_ref,
+                    subject=mesh_ref,
+                    predicate=EXACT_MATCH,
+                    object=icd_ref,
                     evidence=[
                         SimpleEvidence(
                             mapping_set=MappingSet(
@@ -110,9 +110,9 @@ def _get_mesh_to_icd_via_snomedct() -> list[Mapping]:
             )
             rows.append(
                 Mapping(
-                    s=icd_ref,
-                    p=EXACT_MATCH,
-                    o=snomed_ref,
+                    subject=icd_ref,
+                    predicate=EXACT_MATCH,
+                    object=snomed_ref,
                     evidence=[
                         SimpleEvidence(
                             mapping_set=MappingSet(
@@ -144,9 +144,9 @@ def _get_mesh_to_snomedct_via_icd() -> list[Mapping]:
         mesh_ref = Reference(prefix="mesh", identifier=mesh_id)
         rows.append(
             Mapping(
-                s=mesh_ref,
-                p=EXACT_MATCH,
-                o=snomed_ref,
+                subject=mesh_ref,
+                predicate=EXACT_MATCH,
+                object=snomed_ref,
                 evidence=[
                     SimpleEvidence(
                         mapping_set=MappingSet(
@@ -167,9 +167,9 @@ def _get_mesh_to_snomedct_via_icd() -> list[Mapping]:
         else:
             rows.append(
                 Mapping(
-                    s=mesh_ref,
-                    p=EXACT_MATCH,
-                    o=icd_ref,
+                    subject=mesh_ref,
+                    predicate=EXACT_MATCH,
+                    object=icd_ref,
                     evidence=[
                         SimpleEvidence(
                             mapping_set=MappingSet(
@@ -183,9 +183,9 @@ def _get_mesh_to_snomedct_via_icd() -> list[Mapping]:
             )
             rows.append(
                 Mapping(
-                    s=icd_ref,
-                    p=EXACT_MATCH,
-                    o=snomed_ref,
+                    subject=icd_ref,
+                    predicate=EXACT_MATCH,
+                    object=snomed_ref,
                     evidence=[
                         SimpleEvidence(
                             mapping_set=MappingSet(

--- a/src/semra/sources/clo.py
+++ b/src/semra/sources/clo.py
@@ -137,9 +137,9 @@ def get_clo_mappings(confidence: float = 0.8) -> list[Mapping]:
 
                 mappings.append(
                     Mapping(
-                        s=Reference(prefix="clo", identifier=clo_id),
-                        p=DB_XREF,
-                        o=Reference(prefix=prefix, identifier=identifier),
+                        subject=Reference(prefix="clo", identifier=clo_id),
+                        predicate=DB_XREF,
+                        object=Reference(prefix=prefix, identifier=identifier),
                         evidence=[
                             SimpleEvidence(
                                 justification=UNSPECIFIED_MAPPING, mapping_set=mapping_set

--- a/src/semra/sources/compath.py
+++ b/src/semra/sources/compath.py
@@ -26,9 +26,9 @@ def _get_df(name: str, *, sha: str, sep: str = ",") -> list[Mapping]:
 
     return [
         Mapping(
-            s=Reference(prefix=s_p, identifier=_fix_kegg_identifier(s_p, s_i)),
-            p=EXACT_MATCH,
-            o=Reference(prefix=t_p, identifier=_fix_kegg_identifier(t_p, t_i)),
+            subject=Reference(prefix=s_p, identifier=_fix_kegg_identifier(s_p, s_i)),
+            predicate=EXACT_MATCH,
+            object=Reference(prefix=t_p, identifier=_fix_kegg_identifier(t_p, t_i)),
             evidence=[
                 SimpleEvidence(
                     mapping_set=MappingSet(name=name, confidence=0.99),

--- a/src/semra/sources/famplex.py
+++ b/src/semra/sources/famplex.py
@@ -28,9 +28,9 @@ def get_fplx_mappings() -> list[Mapping]:
     df = df[df["target_prefix"] != "MEDSCAN"]
     rv = [
         Mapping(
-            s=Reference(prefix="fplx", identifier=source_id),
-            p=EXACT_MATCH,
-            o=Reference(
+            subject=Reference(prefix="fplx", identifier=source_id),
+            predicate=EXACT_MATCH,
+            object=Reference(
                 prefix=bioregistry.normalize_prefix(target_prefix),
                 identifier=bioregistry.standardize_identifier(target_prefix, target_id),
             ),

--- a/src/semra/sources/gilda.py
+++ b/src/semra/sources/gilda.py
@@ -39,12 +39,12 @@ def get_gilda_mappings(confidence: float = 0.95) -> list[Mapping]:
         if not sp or not tp:
             continue
         m = Mapping(
-            s=Reference(
+            subject=Reference(
                 prefix=bioregistry.normalize_prefix(sp),
                 identifier=bioregistry.standardize_identifier(sp, si),
             ),
-            p=EXACT_MATCH,
-            o=Reference(
+            predicate=EXACT_MATCH,
+            object=Reference(
                 prefix=bioregistry.normalize_prefix(tp),
                 identifier=bioregistry.standardize_identifier(tp, ti),
             ),

--- a/src/semra/sources/intact.py
+++ b/src/semra/sources/intact.py
@@ -42,14 +42,14 @@ def _get_mappings(url: str, target_prefix: str) -> list[Mapping]:
     rv = []
     for intact_id, target_identifier in df.values:
         try:
-            o = Reference(prefix=target_prefix, identifier=target_identifier)
+            obj = Reference(prefix=target_prefix, identifier=target_identifier)
         except ValidationError:
             tqdm.write(f"[intact:{intact_id}] invalid xref: {target_prefix}:{target_identifier}")
             continue
         mapping = Mapping(
-            s=Reference(prefix="intact", identifier=intact_id),
-            p=EXACT_MATCH,
-            o=o,
+            subject=Reference(prefix="intact", identifier=intact_id),
+            predicate=EXACT_MATCH,
+            object=obj,
             evidence=[evidence],
         )
         rv.append(mapping)

--- a/src/semra/sources/ncit.py
+++ b/src/semra/sources/ncit.py
@@ -108,14 +108,14 @@ def _df_to_mappings(
         desc=f"Processing {source_prefix}",
     ):
         try:
-            o = Reference(prefix=target_prefix, identifier=target_id)
+            obj = Reference(prefix=target_prefix, identifier=target_id)
         except ValidationError:
             tqdm.write(f"[ncit:{source_id} invalid xref: {target_prefix}:{target_id}")
             continue
         mapping = Mapping(
-            s=Reference(prefix=source_prefix, identifier=source_id),
-            p=EXACT_MATCH,
-            o=o,
+            subject=Reference(prefix=source_prefix, identifier=source_id),
+            predicate=EXACT_MATCH,
+            object=obj,
             evidence=[evidence_],
         )
         rv.append(mapping)

--- a/src/semra/sources/omim.py
+++ b/src/semra/sources/omim.py
@@ -17,12 +17,12 @@ def get_omim_gene_mappings() -> list[Mapping]:
     mapping_set = MappingSet(name="OMIM", confidence=0.99)
     rv = []
     for identifier, _type, entrez_id, _hgnc_symbol, ensembl_id in df.values:
-        s = Reference(prefix="omim", identifier=identifier)
+        subject = Reference(prefix="omim", identifier=identifier)
         if pd.notna(entrez_id):
             mapping = Mapping(
-                s=s,
-                p=EXACT_MATCH,
-                o=Reference(prefix="ncbigene", identifier=entrez_id),
+                subject=subject,
+                predicate=EXACT_MATCH,
+                object=Reference(prefix="ncbigene", identifier=entrez_id),
                 evidence=[
                     SimpleEvidence(justification=UNSPECIFIED_MAPPING, mapping_set=mapping_set)
                 ],
@@ -31,9 +31,9 @@ def get_omim_gene_mappings() -> list[Mapping]:
         # TODO handle dependencies for mapping gene symbol
         if pd.notna(ensembl_id):
             mapping = Mapping(
-                s=s,
-                p=EXACT_MATCH,
-                o=Reference(prefix="ensembl", identifier=ensembl_id),
+                subject=subject,
+                predicate=EXACT_MATCH,
+                object=Reference(prefix="ensembl", identifier=ensembl_id),
                 evidence=[
                     SimpleEvidence(justification=UNSPECIFIED_MAPPING, mapping_set=mapping_set)
                 ],

--- a/src/semra/sources/pubchem.py
+++ b/src/semra/sources/pubchem.py
@@ -42,9 +42,9 @@ def get_pubchem_mesh_mappings(version: str | None = None) -> list[Mapping]:
                 logger.debug("[mesh] needs curating: %s", mesh_name)
             continue
         mapping = Mapping(
-            s=Reference(prefix="pubchem.compound", identifier=pubchem),
-            o=Reference(prefix="mesh", identifier=mesh_id),
-            p=EXACT_MATCH,
+            subject=Reference(prefix="pubchem.compound", identifier=pubchem),
+            object=Reference(prefix="mesh", identifier=mesh_id),
+            predicate=EXACT_MATCH,
             evidence=[
                 SimpleEvidence(
                     justification=UNSPECIFIED_MAPPING,

--- a/src/semra/sources/wikidata.py
+++ b/src/semra/sources/wikidata.py
@@ -77,13 +77,13 @@ def _help(
         if not wikidata_id.startswith("Q"):
             continue
         try:
-            o = Reference(prefix=target_prefix, identifier=_clean_xref_id(target_prefix, xref_id))
+            obj = Reference(prefix=target_prefix, identifier=_clean_xref_id(target_prefix, xref_id))
         except ValueError:
             continue
         mapping = Mapping(
-            s=Reference(prefix="wikidata", identifier=wikidata_id),
-            p=_predicate,
-            o=o,
+            subject=Reference(prefix="wikidata", identifier=wikidata_id),
+            predicate=_predicate,
+            object=obj,
             evidence=[SimpleEvidence(justification=UNSPECIFIED_MAPPING, mapping_set=mapping_set)],
         )
         rv.append(mapping)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -65,7 +65,7 @@ def _get_references(
 
 
 def _exact(s: Reference, o: Reference, evidence: list[SimpleEvidence] | None = None) -> Mapping:
-    return Mapping(s=s, p=EXACT_MATCH, o=o, evidence=evidence or [])
+    return Mapping(subject=s, predicate=EXACT_MATCH, object=o, evidence=evidence or [])
 
 
 EV = SimpleEvidence(
@@ -81,8 +81,8 @@ class TestOperations(unittest.TestCase):
     def test_path(self) -> None:
         """Test quickly creating mapping lists."""
         r1, r2, r3 = _get_references(3)
-        m1 = Mapping(s=r1, p=EXACT_MATCH, o=r2)
-        m2 = Mapping(s=r2, p=BROAD_MATCH, o=r3)
+        m1 = Mapping(subject=r1, predicate=EXACT_MATCH, object=r2)
+        m2 = Mapping(subject=r2, predicate=BROAD_MATCH, object=r3)
         self.assertEqual([m1], line(r1, EXACT_MATCH, r2))
         self.assertEqual([m1, m2], line(r1, EXACT_MATCH, r2, BROAD_MATCH, r3))
 
@@ -90,12 +90,14 @@ class TestOperations(unittest.TestCase):
         """Test flipping a symmetric relation (e.g., exact match)."""
         chebi_reference = Reference(prefix="chebi", identifier="10001")
         mesh_reference = Reference(prefix="mesh", identifier="C067604")
-        mapping = Mapping(s=chebi_reference, p=EXACT_MATCH, o=mesh_reference, evidence=[EV])
+        mapping = Mapping(
+            subject=chebi_reference, predicate=EXACT_MATCH, object=mesh_reference, evidence=[EV]
+        )
         new_mapping = flip(mapping)
         self.assertIsNotNone(new_mapping)
-        self.assertEqual(mesh_reference, new_mapping.s)
-        self.assertEqual(EXACT_MATCH, new_mapping.p)
-        self.assertEqual(chebi_reference, new_mapping.o)
+        self.assertEqual(mesh_reference, new_mapping.subject)
+        self.assertEqual(EXACT_MATCH, new_mapping.predicate)
+        self.assertEqual(chebi_reference, new_mapping.object)
         self.assertEqual(1, len(new_mapping.evidence))
         self.assertIsInstance(new_mapping.evidence[0], ReasonedEvidence)
         evidence: ReasonedEvidence = cast(ReasonedEvidence, new_mapping.evidence[0])
@@ -106,20 +108,24 @@ class TestOperations(unittest.TestCase):
         """Test flipping asymmetric relations (e.g., narrow and broad match)."""
         docetaxel_mesh = Reference(prefix="mesh", identifier="D000077143")
         docetaxel_anhydrous_chebi = Reference(prefix="chebi", identifier="4672")
-        narrow_mapping = Mapping(s=docetaxel_mesh, p=NARROW_MATCH, o=docetaxel_anhydrous_chebi)
-        broad_mapping = Mapping(o=docetaxel_mesh, p=BROAD_MATCH, s=docetaxel_anhydrous_chebi)
+        narrow_mapping = Mapping(
+            subject=docetaxel_mesh, predicate=NARROW_MATCH, object=docetaxel_anhydrous_chebi
+        )
+        broad_mapping = Mapping(
+            object=docetaxel_mesh, predicate=BROAD_MATCH, subject=docetaxel_anhydrous_chebi
+        )
 
         actual_1: Mapping = flip(narrow_mapping)
         self.assertIsNotNone(actual_1)
-        self.assertEqual(docetaxel_anhydrous_chebi, actual_1.s)
-        self.assertEqual(BROAD_MATCH, actual_1.p)
-        self.assertEqual(docetaxel_mesh, actual_1.o)
+        self.assertEqual(docetaxel_anhydrous_chebi, actual_1.subject)
+        self.assertEqual(BROAD_MATCH, actual_1.predicate)
+        self.assertEqual(docetaxel_mesh, actual_1.object)
 
         actual_2: Mapping = flip(broad_mapping)
         self.assertIsNotNone(actual_2)
-        self.assertEqual(docetaxel_mesh, actual_2.s)
-        self.assertEqual(NARROW_MATCH, actual_2.p)
-        self.assertEqual(docetaxel_anhydrous_chebi, actual_2.o)
+        self.assertEqual(docetaxel_mesh, actual_2.subject)
+        self.assertEqual(NARROW_MATCH, actual_2.predicate)
+        self.assertEqual(docetaxel_anhydrous_chebi, actual_2.object)
 
     def test_index(self) -> None:
         """Test indexing semantic mappings."""
@@ -131,8 +137,8 @@ class TestOperations(unittest.TestCase):
             justification=Reference(prefix="semapv", identifier="ManualMappingCuration"),
             mapping_set=MS,
         )
-        m1 = Mapping(s=r1, p=EXACT_MATCH, o=r2, evidence=[e1])
-        m2 = Mapping(s=r1, p=EXACT_MATCH, o=r2, evidence=[e2])
+        m1 = Mapping(subject=r1, predicate=EXACT_MATCH, object=r2, evidence=[e1])
+        m2 = Mapping(subject=r1, predicate=EXACT_MATCH, object=r2, evidence=[e2])
         index = get_index([m1, m2], progress=False)
         self.assertIn(m1.triple, index)
         self.assertEqual(1, len(index))
@@ -218,12 +224,12 @@ class TestOperations(unittest.TestCase):
         """Test inferring broad matches."""
         r1, r2, r3, r4 = _get_references(4, different_prefixes=True)
         m1, m2, m3 = line(r1, EXACT_MATCH, r2, BROAD_MATCH, r3, EXACT_MATCH, r4)
-        m4 = Mapping(s=r1, p=BROAD_MATCH, o=r3, evidence=[EV])
-        m5 = Mapping(s=r1, p=BROAD_MATCH, o=r4, evidence=[EV])
-        m6 = Mapping(s=r2, p=BROAD_MATCH, o=r4, evidence=[EV])
-        m4_i = Mapping(o=r1, p=NARROW_MATCH, s=r3, evidence=[EV])
-        m5_i = Mapping(o=r1, p=NARROW_MATCH, s=r4, evidence=[EV])
-        m6_i = Mapping(o=r2, p=NARROW_MATCH, s=r4, evidence=[EV])
+        m4 = Mapping(subject=r1, predicate=BROAD_MATCH, object=r3, evidence=[EV])
+        m5 = Mapping(subject=r1, predicate=BROAD_MATCH, object=r4, evidence=[EV])
+        m6 = Mapping(subject=r2, predicate=BROAD_MATCH, object=r4, evidence=[EV])
+        m4_i = Mapping(object=r1, predicate=NARROW_MATCH, subject=r3, evidence=[EV])
+        m5_i = Mapping(object=r1, predicate=NARROW_MATCH, subject=r4, evidence=[EV])
+        m6_i = Mapping(object=r2, predicate=NARROW_MATCH, subject=r4, evidence=[EV])
 
         # Check inference over two steps
         self.assert_same_triples(
@@ -252,12 +258,12 @@ class TestOperations(unittest.TestCase):
         """Test inferring broad matches."""
         r1, r2, r3, r4 = _get_references(4, different_prefixes=True)
         m1, m2, m3 = line(r1, BROAD_MATCH, r2, EXACT_MATCH, r3, BROAD_MATCH, r4)
-        m4 = Mapping(s=r1, p=BROAD_MATCH, o=r3)
-        m5 = Mapping(s=r1, p=BROAD_MATCH, o=r4)
-        m6 = Mapping(s=r2, p=BROAD_MATCH, o=r4)
-        m4_i = Mapping(o=r1, p=NARROW_MATCH, s=r3)
-        m5_i = Mapping(o=r1, p=NARROW_MATCH, s=r4)
-        m6_i = Mapping(o=r2, p=NARROW_MATCH, s=r4)
+        m4 = Mapping(subject=r1, predicate=BROAD_MATCH, object=r3)
+        m5 = Mapping(subject=r1, predicate=BROAD_MATCH, object=r4)
+        m6 = Mapping(subject=r2, predicate=BROAD_MATCH, object=r4)
+        m4_i = Mapping(object=r1, predicate=NARROW_MATCH, subject=r3)
+        m5_i = Mapping(object=r1, predicate=NARROW_MATCH, subject=r4)
+        m6_i = Mapping(object=r2, predicate=NARROW_MATCH, subject=r4)
 
         # Check inference over two steps
         self.assert_same_triples(
@@ -280,8 +286,8 @@ class TestOperations(unittest.TestCase):
         """Test inferring narrow matches."""
         r1, r2, r3 = _get_references(3, different_prefixes=True)
         m1, m2 = line(r1, EXACT_MATCH, r2, NARROW_MATCH, r3)
-        m3 = Mapping(s=r1, p=NARROW_MATCH, o=r3)
-        m3_i = Mapping(o=r1, p=BROAD_MATCH, s=r3)
+        m3 = Mapping(subject=r1, predicate=NARROW_MATCH, object=r3)
+        m3_i = Mapping(object=r1, predicate=BROAD_MATCH, subject=r3)
         self.assert_same_triples(
             [m1, m2, m3], infer_chains([m1, m2], backwards=False, progress=False)
         )
@@ -292,13 +298,13 @@ class TestOperations(unittest.TestCase):
     def test_mixed_inference_1(self) -> None:
         """Test inferring over a mix of narrow, broad, and exact matches."""
         r1, r2, r3 = _get_references(3, different_prefixes=True)
-        m1 = Mapping(s=r1, p=EXACT_MATCH, o=r2)
-        m2 = Mapping(s=r2, p=NARROW_MATCH, o=r3)
-        m3 = Mapping(s=r1, p=NARROW_MATCH, o=r3)
+        m1 = Mapping(subject=r1, predicate=EXACT_MATCH, object=r2)
+        m2 = Mapping(subject=r2, predicate=NARROW_MATCH, object=r3)
+        m3 = Mapping(subject=r1, predicate=NARROW_MATCH, object=r3)
 
-        m4 = Mapping(s=r2, p=EXACT_MATCH, o=r1)
-        m5 = Mapping(s=r3, p=BROAD_MATCH, o=r2)
-        m6 = Mapping(s=r3, p=BROAD_MATCH, o=r1)
+        m4 = Mapping(subject=r2, predicate=EXACT_MATCH, object=r1)
+        m5 = Mapping(subject=r3, predicate=BROAD_MATCH, object=r2)
+        m6 = Mapping(subject=r3, predicate=BROAD_MATCH, object=r1)
 
         mappings = [m1, m2]
         mappings = infer_reversible(mappings, progress=False)
@@ -312,9 +318,9 @@ class TestOperations(unittest.TestCase):
         r11, r12 = _get_references(2, prefix=PREFIX_A)
         r21, r22 = _get_references(2, prefix=PREFIX_B)
         (r31,) = _get_references(1, prefix=PREFIX_C)
-        m1 = Mapping(s=r11, p=EXACT_MATCH, o=r21)
-        m2 = Mapping(s=r12, p=EXACT_MATCH, o=r22)
-        m3 = Mapping(s=r11, p=EXACT_MATCH, o=r31)
+        m1 = Mapping(subject=r11, predicate=EXACT_MATCH, object=r21)
+        m2 = Mapping(subject=r12, predicate=EXACT_MATCH, object=r22)
+        m3 = Mapping(subject=r11, predicate=EXACT_MATCH, object=r31)
         mappings = [m1, m2, m3]
         self.assert_same_triples(
             [m1, m2], keep_prefixes(mappings, {PREFIX_A, PREFIX_B}, progress=False)
@@ -324,9 +330,9 @@ class TestOperations(unittest.TestCase):
         """Test filtering out mappings within a given prefix."""
         r11, r12, r13 = _get_references(3, prefix=PREFIX_A)
         r21, r22 = _get_references(2, prefix=PREFIX_B)
-        m1 = Mapping(s=r11, p=EXACT_MATCH, o=r21)
-        m2 = Mapping(s=r12, p=EXACT_MATCH, o=r22)
-        m3 = Mapping(s=r11, p=EXACT_MATCH, o=r13)
+        m1 = Mapping(subject=r11, predicate=EXACT_MATCH, object=r21)
+        m2 = Mapping(subject=r12, predicate=EXACT_MATCH, object=r22)
+        m3 = Mapping(subject=r11, predicate=EXACT_MATCH, object=r13)
         mappings = [m1, m2, m3]
         self.assert_same_triples([m1, m2], filter_self_matches(mappings, progress=False))
 
@@ -334,8 +340,8 @@ class TestOperations(unittest.TestCase):
         """Test filtering out mappings within a given prefix."""
         r11, r12 = _get_references(2, prefix=PREFIX_A)
         r21, r22 = _get_references(2, prefix=PREFIX_B)
-        m1 = Mapping(s=r11, p=EXACT_MATCH, o=r21)
-        m2 = Mapping(s=r12, p=EXACT_MATCH, o=r22)
+        m1 = Mapping(subject=r11, predicate=EXACT_MATCH, object=r21)
+        m2 = Mapping(subject=r12, predicate=EXACT_MATCH, object=r22)
         mappings = [m1, m2]
         negative = [m2]
         self.assert_same_triples([m1], filter_mappings(mappings, negative, progress=False))
@@ -345,10 +351,10 @@ class TestOperations(unittest.TestCase):
         r11, r12 = _get_references(2, prefix=PREFIX_A)
         r21, r22 = _get_references(2, prefix=PREFIX_B)
         (r31,) = _get_references(1, prefix=PREFIX_C)
-        m1 = Mapping(s=r11, p=EXACT_MATCH, o=r21)
-        m2 = Mapping(s=r12, p=EXACT_MATCH, o=r22)
-        m2_i = Mapping(o=r12, p=EXACT_MATCH, s=r22)
-        m3 = Mapping(s=r11, p=EXACT_MATCH, o=r31)
+        m1 = Mapping(subject=r11, predicate=EXACT_MATCH, object=r21)
+        m2 = Mapping(subject=r12, predicate=EXACT_MATCH, object=r22)
+        m2_i = Mapping(object=r12, predicate=EXACT_MATCH, subject=r22)
+        m3 = Mapping(subject=r11, predicate=EXACT_MATCH, object=r31)
         mappings = [m1, m2, m2_i, m3]
         self.assert_same_triples(
             [m1, m2], project(mappings, PREFIX_A, PREFIX_B, progress=False, return_sus=False)
@@ -360,12 +366,12 @@ class TestOperations(unittest.TestCase):
         b1, b2, b3 = _get_references(3, prefix=PREFIX_B)
 
         # Subject duplicate
-        m1 = Mapping(s=a1, p=EXACT_MATCH, o=b1)
-        m2 = Mapping(s=a1, p=EXACT_MATCH, o=b3)
-        m3 = Mapping(s=a2, p=EXACT_MATCH, o=b2)
+        m1 = Mapping(subject=a1, predicate=EXACT_MATCH, object=b1)
+        m2 = Mapping(subject=a1, predicate=EXACT_MATCH, object=b3)
+        m3 = Mapping(subject=a2, predicate=EXACT_MATCH, object=b2)
         self.assert_same_triples([m1, m2], get_many_to_many([m1, m2, m3]))
 
-        m4 = Mapping(s=a3, p=EXACT_MATCH, o=b2)
+        m4 = Mapping(subject=a3, predicate=EXACT_MATCH, object=b2)
         self.assert_same_triples([m3, m4], get_many_to_many([m2, m3, m4]))
 
     def test_filter_confidence(self) -> None:
@@ -373,10 +379,16 @@ class TestOperations(unittest.TestCase):
         (a1, a2) = _get_references(2, prefix=PREFIX_A)
         (b1, b2) = _get_references(2, prefix=PREFIX_B)
         m1 = Mapping(
-            s=a1, p=DB_XREF, o=b1, evidence=[SimpleEvidence(confidence=0.95, mapping_set=MS)]
+            subject=a1,
+            predicate=DB_XREF,
+            object=b1,
+            evidence=[SimpleEvidence(confidence=0.95, mapping_set=MS)],
         )
         m2 = Mapping(
-            s=a1, p=DB_XREF, o=b1, evidence=[SimpleEvidence(confidence=0.65, mapping_set=MS)]
+            subject=a1,
+            predicate=DB_XREF,
+            object=b1,
+            evidence=[SimpleEvidence(confidence=0.65, mapping_set=MS)],
         )
         mmm = list(api.filter_minimum_confidence([m1, m2], cutoff=0.7))
         self.assertEqual([m1], mmm)
@@ -387,12 +399,12 @@ class TestOperations(unittest.TestCase):
         b1, b2 = _get_references(2, prefix=PREFIX_B)
         c1, c2 = _get_references(2, prefix=PREFIX_C)
         ev = SimpleEvidence(confidence=0.95, mapping_set=MS)
-        m1 = Mapping(s=a1, p=EXACT_MATCH, o=b1, evidence=[ev])
-        m2 = Mapping(s=b1, p=EXACT_MATCH, o=a1, evidence=[ev])
-        m3 = Mapping(s=a2, p=EXACT_MATCH, o=b2, evidence=[ev])
-        m4 = Mapping(s=b2, p=EXACT_MATCH, o=a2, evidence=[ev])
-        m5 = Mapping(s=b1, p=EXACT_MATCH, o=c1, evidence=[ev])
-        m6 = Mapping(s=c1, p=EXACT_MATCH, o=b1, evidence=[ev])
+        m1 = Mapping(subject=a1, predicate=EXACT_MATCH, object=b1, evidence=[ev])
+        m2 = Mapping(subject=b1, predicate=EXACT_MATCH, object=a1, evidence=[ev])
+        m3 = Mapping(subject=a2, predicate=EXACT_MATCH, object=b2, evidence=[ev])
+        m4 = Mapping(subject=b2, predicate=EXACT_MATCH, object=a2, evidence=[ev])
+        m5 = Mapping(subject=b1, predicate=EXACT_MATCH, object=c1, evidence=[ev])
+        m6 = Mapping(subject=c1, predicate=EXACT_MATCH, object=b1, evidence=[ev])
 
         terms = {
             PREFIX_A: [a1, a2],
@@ -425,10 +437,12 @@ class TestOperations(unittest.TestCase):
         b1, b2 = _get_references(2, prefix=PREFIX_B)
         c1, _ = _get_references(2, prefix=PREFIX_C)
         ev = SimpleEvidence(confidence=0.95, mapping_set=MS)
-        m1 = Mapping(s=a1, p=EXACT_MATCH, o=b1, evidence=[ev])
-        m2 = Mapping(s=b1, p=EXACT_MATCH, o=c1, evidence=[ev])
-        m3 = Mapping(s=a2, p=EXACT_MATCH, o=b2, evidence=[ev])
-        m4 = Mapping(s=a2, p=DB_XREF, o=b2, evidence=[ev])  # this shouldn't hae an effect
+        m1 = Mapping(subject=a1, predicate=EXACT_MATCH, object=b1, evidence=[ev])
+        m2 = Mapping(subject=b1, predicate=EXACT_MATCH, object=c1, evidence=[ev])
+        m3 = Mapping(subject=a2, predicate=EXACT_MATCH, object=b2, evidence=[ev])
+        m4 = Mapping(
+            subject=a2, predicate=DB_XREF, object=b2, evidence=[ev]
+        )  # this shouldn't hae an effect
         mappings = [m1, m2, m3, m4]
         self.assertEqual(
             {frozenset([PREFIX_A, PREFIX_B]): 1, frozenset([PREFIX_A, PREFIX_B, PREFIX_C]): 1},
@@ -442,10 +456,12 @@ class TestOperations(unittest.TestCase):
         b1, b2 = _get_references(2, prefix=PREFIX_B)
         c1, _ = _get_references(2, prefix=PREFIX_C)
         ev = SimpleEvidence(confidence=0.95, mapping_set=MS)
-        m1 = Mapping(s=a1, p=EXACT_MATCH, o=b1, evidence=[ev])
-        m2 = Mapping(s=b1, p=EXACT_MATCH, o=c1, evidence=[ev])
-        m3 = Mapping(s=a2, p=EXACT_MATCH, o=b2, evidence=[ev])
-        m4 = Mapping(s=a2, p=DB_XREF, o=b2, evidence=[ev])  # this shouldn't hae an effect
+        m1 = Mapping(subject=a1, predicate=EXACT_MATCH, object=b1, evidence=[ev])
+        m2 = Mapping(subject=b1, predicate=EXACT_MATCH, object=c1, evidence=[ev])
+        m3 = Mapping(subject=a2, predicate=EXACT_MATCH, object=b2, evidence=[ev])
+        m4 = Mapping(
+            subject=a2, predicate=DB_XREF, object=b2, evidence=[ev]
+        )  # this shouldn't hae an effect
         mappings = [m1, m2, m3, m4]
         self.assertEqual(mappings, from_digraph(to_digraph(mappings)))
 
@@ -454,8 +470,8 @@ class TestOperations(unittest.TestCase):
         a1, a2 = _get_references(2, prefix=PREFIX_A)
         b1, b2 = _get_references(2, prefix=PREFIX_B)
         ev = SimpleEvidence(confidence=0.95, mapping_set=MS)
-        m1 = Mapping(s=a1, p=EXACT_MATCH, o=b1, evidence=[ev])
-        m2 = Mapping(s=a2, p=EXACT_MATCH, o=b2, evidence=[ev])
+        m1 = Mapping(subject=a1, predicate=EXACT_MATCH, object=b1, evidence=[ev])
+        m2 = Mapping(subject=a2, predicate=EXACT_MATCH, object=b2, evidence=[ev])
 
         rows = [("r1", a1.curie), ("r2", a2.curie)]
         df = pd.DataFrame(rows, columns=["label", "curie"])
@@ -478,9 +494,9 @@ class TestUpgrades(unittest.TestCase):
         original_confidence = 0.95
         mutation_confidence = 0.80
         m1 = Mapping(
-            s=a1,
-            p=DB_XREF,
-            o=b1,
+            subject=a1,
+            predicate=DB_XREF,
+            object=b1,
             evidence=[SimpleEvidence(confidence=original_confidence, mapping_set=MS)],
         )
         new_mappings = infer_mutations(
@@ -493,9 +509,9 @@ class TestUpgrades(unittest.TestCase):
         self.assertEqual(2, len(new_mappings))
         new_m1, new_m2 = new_mappings
         self.assertEqual(m1, new_m1)
-        self.assertEqual(a1, new_m2.s)
-        self.assertEqual(EXACT_MATCH, new_m2.p)
-        self.assertEqual(b1, new_m2.o)
+        self.assertEqual(a1, new_m2.subject)
+        self.assertEqual(EXACT_MATCH, new_m2.predicate)
+        self.assertEqual(b1, new_m2.object)
         self.assertEqual(1, len(new_m2.evidence))
         new_evidence = new_m2.evidence[0]
         self.assertIsInstance(new_evidence, ReasonedEvidence)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -53,12 +53,12 @@ class TestIOLocal(unittest.TestCase):
         """Test loading content from PyOBO."""
         mappings = from_pyobo("doid")
         for mapping in mappings:
-            self.assertEqual("doid", mapping.s.prefix)
+            self.assertEqual("doid", mapping.subject.prefix)
 
         mappings_2 = from_pyobo("doid", "mesh")
         for mapping in mappings_2:
-            self.assertEqual("doid", mapping.s.prefix)
-            self.assertEqual("mesh", mapping.o.prefix)
+            self.assertEqual("doid", mapping.subject.prefix)
+            self.assertEqual("mesh", mapping.object.prefix)
 
 
 class TestSSSOM(unittest.TestCase):
@@ -74,8 +74,8 @@ class TestSSSOM(unittest.TestCase):
             justification=UNSPECIFIED_MAPPING,
         )
         expected_mappings = [
-            Mapping(s=a1, p=EXACT_MATCH, o=b1, evidence=[expected_evidence]),
-            Mapping(s=a2, p=EXACT_MATCH, o=b2, evidence=[expected_evidence]),
+            Mapping(subject=a1, predicate=EXACT_MATCH, object=b1, evidence=[expected_evidence]),
+            Mapping(subject=a2, predicate=EXACT_MATCH, object=b2, evidence=[expected_evidence]),
         ]
 
         # Test 1 - from kwargs
@@ -161,8 +161,8 @@ class TestSSSOM(unittest.TestCase):
             justification=UNSPECIFIED_MAPPING,
         )
         expected_mappings = [
-            Mapping(s=a1, p=EXACT_MATCH, o=b1, evidence=[expected_evidence]),
-            Mapping(s=a2, p=EXACT_MATCH, o=b2, evidence=[expected_evidence]),
+            Mapping(subject=a1, predicate=EXACT_MATCH, object=b1, evidence=[expected_evidence]),
+            Mapping(subject=a2, predicate=EXACT_MATCH, object=b2, evidence=[expected_evidence]),
         ]
 
         rows = [

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -20,9 +20,9 @@ TEST_MAPPING_SET = MappingSet(
 )
 TEST_MAPPINGS = [
     Mapping(
-        s=a1,
-        p=EXACT_MATCH,
-        o=b1,
+        subject=a1,
+        predicate=EXACT_MATCH,
+        object=b1,
         evidence=[
             SimpleEvidence(
                 justification=MANUAL_MAPPING,
@@ -51,8 +51,8 @@ class TestPipeline(unittest.TestCase):
         self.assertEqual(1, len(mappings))
         mapping = mappings[0]
         self.assertIsInstance(mapping, Mapping)
-        self.assertEqual(a1, mapping.s)
-        self.assertEqual(b1, mapping.o)
+        self.assertEqual(a1, mapping.subject)
+        self.assertEqual(b1, mapping.object)
         self.assertEqual(1, len(mapping.evidence))
         ev = mapping.evidence[0]
         self.assertIsInstance(ev, SimpleEvidence)


### PR DESCRIPTION
This PR adds more readable names and prepares to superset the mapping class with the more generic `curies.Triple` interface