### PR TITLE
Add tests for web implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ tests = [
     "pytest",
     "coverage[toml]",
     "sssom>=0.4.16",
+    "httpx",
 ]
 docs = [
     "sphinx>=8",

--- a/src/semra/client.py
+++ b/src/semra/client.py
@@ -134,11 +134,11 @@ class BaseClient:
 
     def get_exact_matches(
         self, curie: ReferenceHint, *, max_distance: int | None = None
-    ) -> dict[Reference, str]:
+    ) -> dict[Reference, str] | None:
         """Get a mapping of references->name for all concepts equivalent to the given concept."""
         raise NotImplementedError
 
-    def get_connected_component_graph(self, curie: ReferenceHint) -> nx.MultiDiGraph:
+    def get_connected_component_graph(self, curie: ReferenceHint) -> nx.MultiDiGraph | None:
         """Get a networkx MultiDiGraph representing the connected component of mappings around the given CURIE.
 
         :param curie: A CURIE string or reference
@@ -412,7 +412,7 @@ as label, count UNION ALL
 
     def get_exact_matches(
         self, curie: ReferenceHint, *, max_distance: int | None = None
-    ) -> dict[Reference, str]:
+    ) -> dict[Reference, str] | None:
         """Get a mapping of references->name for all concepts equivalent to the given concept."""
         if isinstance(curie, Reference):
             curie = curie.curie
@@ -468,7 +468,7 @@ as label, count UNION ALL
         relations = [r[0] for r in self.read_query(edge_query, curies=sorted(component_curies))]
         return nodes, relations
 
-    def get_connected_component_graph(self, curie: ReferenceHint) -> nx.MultiDiGraph:
+    def get_connected_component_graph(self, curie: ReferenceHint) -> nx.MultiDiGraph | None:
         """Get a networkx MultiDiGraph representing the connected component of mappings around the given CURIE.
 
         :param curie: A CURIE string or reference
@@ -484,8 +484,8 @@ as label, count UNION ALL
                 g.add_edge(
                     path.start_node["curie"],
                     path.end_node["curie"],
-                    key=relationship.id,
-                    type=relationship.type,
+                    key=relationship.id,  # this is the mapping's CURIE
+                    type=relationship.type,  # this is the predicate CURIE
                 )
         return g
 

--- a/src/semra/client.py
+++ b/src/semra/client.py
@@ -7,7 +7,7 @@ import os
 import typing as t
 from collections import Counter
 from textwrap import dedent
-from typing import Any, NamedTuple, Self, TypeAlias, cast
+from typing import Any, NamedTuple, TypeAlias, cast
 
 import bioregistry
 import neo4j
@@ -15,6 +15,7 @@ import neo4j.graph
 import networkx as nx
 import pydantic
 from neo4j import ManagedTransaction, unit_of_work
+from typing_extensions import Self
 
 import semra
 from semra import Evidence, MappingSet, Reference, SimpleEvidence

--- a/src/semra/struct.py
+++ b/src/semra/struct.py
@@ -124,6 +124,8 @@ class MappingSet(
     https://mapping-commons.github.io/sssom/MappingSet.
     """
 
+    model_config = ConfigDict(frozen=True)
+
     purl: str | None = Field(
         None,
         description="The persistent URL (PURL) for the mapping set. While it's optional in SeMRA, this is a required SSSOM field: https://mapping-commons.github.io/sssom/mapping_set_id/",

--- a/src/semra/templates/concept.html
+++ b/src/semra/templates/concept.html
@@ -109,7 +109,7 @@ https://bioregistry.io/{{ ref.curie }}
                         {% if name %}{{ name }}{% endif %}
                     </td>
                     <td>
-                        <a href="{{ url_for('view_concept', curie=exact_match.curie) }}">SeMRA</a>
+                        <a href="{{ url_for('.view_concept', curie=exact_match.curie) }}">SeMRA</a>
                     </td>
                     <td>
                         <a href="{{ bioregistry_href(exact_match) }}">Bioregistry</a>

--- a/src/semra/templates/home.html
+++ b/src/semra/templates/home.html
@@ -38,10 +38,10 @@
         <td><code>
             {%- if is_concept -%}
             {% if has_names %}
-            <a href="{{ url_for('view_concept', curie=key[0]) }}">{{ key[0] }}</a>
+            <a href="{{ url_for('.view_concept', curie=key[0]) }}">{{ key[0] }}</a>
             {% else %}
             FAILURE!
-            <a href="{{ url_for('view_concept', curie=key) }}">{{ key }}</a>
+            <a href="{{ url_for('.view_concept', curie=key) }}">{{ key }}</a>
             {% endif %}
             {%- else -%}
             {% if has_names %}{{ key[0] }}{% else %}{{ key }}{% endif %}
@@ -98,7 +98,7 @@
                     {% for mapping_set in mapping_sets %}
                     <tr>
                         <td class="text-break">
-                            <a href="{{ url_for('view_mapping_set', mapping_set_id=mapping_set.curie) }}">
+                            <a href="{{ url_for('.view_mapping_set', mapping_set_id=mapping_set.curie) }}">
                                 {{ mapping_set.name }}
                             </a>
                         </td>

--- a/src/semra/templates/mapping.html
+++ b/src/semra/templates/mapping.html
@@ -16,11 +16,11 @@
                 </h5>
                 <dl>
                     <dt>Subject</dt>
-                    <dd><a href="{{ url_for('view_concept', curie=mapping.s.curie) }}"><code>{{ mapping.s.curie }}</code></a></dd>
+                    <dd><a href="{{ url_for('view_concept', curie=mapping.subject.curie) }}"><code>{{ mapping.subject.curie }}</code></a></dd>
                     <dt>Predicate</dt>
                     <dd><code>{{ mapping.p.curie }}</code></dd>
                     <dt>Object</dt>
-                    <dd><a href="{{ url_for('view_concept', curie=mapping.o.curie) }}"><code>{{ mapping.o.curie }}</code></a></dd>
+                    <dd><a href="{{ url_for('view_concept', curie=mapping.object.curie) }}"><code>{{ mapping.object.curie }}</code></a></dd>
                     <dt>Evidence</dt>
                     {%- for evidence in mapping.evidence -%}
                     <dd>

--- a/src/semra/templates/mapping.html
+++ b/src/semra/templates/mapping.html
@@ -16,22 +16,22 @@
                 </h5>
                 <dl>
                     <dt>Subject</dt>
-                    <dd><a href="{{ url_for('view_concept', curie=mapping.subject.curie) }}"><code>{{ mapping.subject.curie }}</code></a></dd>
+                    <dd><a href="{{ url_for('.view_concept', curie=mapping.subject.curie) }}"><code>{{ mapping.subject.curie }}</code></a></dd>
                     <dt>Predicate</dt>
-                    <dd><code>{{ mapping.p.curie }}</code></dd>
+                    <dd><code>{{ mapping.predicate.curie }}</code></dd>
                     <dt>Object</dt>
-                    <dd><a href="{{ url_for('view_concept', curie=mapping.object.curie) }}"><code>{{ mapping.object.curie }}</code></a></dd>
+                    <dd><a href="{{ url_for('.view_concept', curie=mapping.object.curie) }}"><code>{{ mapping.object.curie }}</code></a></dd>
                     <dt>Evidence</dt>
                     {%- for evidence in mapping.evidence -%}
                     <dd>
-                        <code>{{ evidence.curie["semra.evidence:" | length:][:8] }}</code><br>
+                        <code>{{ evidence.get_reference(mapping).identifier["semra.evidence:" | length:][:8] }}</code><br>
                         Confidence: {{ evidence.confidence}}<br>
                         Type: {{ evidence.evidence_type }}<br>
                         {% if evidence.author %}
                         Author:<a href="https://bioregistry.io/{{ evidence.author.curie }}">{{ evidence.author.curie }}</a><br>
                         {% endif %}
                         {% if evidence.mapping_set %}
-                        Mapping Set: <a href="{{ url_for('view_mapping_set', curie=evidence.mapping_set.curie) }}">{{evidence.mapping_set.name}}</a>
+                        Mapping Set: <a href="{{ url_for('.view_mapping_set', mapping_set_id=evidence.mapping_set.curie) }}">{{evidence.mapping_set.name}}</a>
                         ({{ evidence.mapping_set.version }},
                         {{ evidence.mapping_set.license }})
                         {% endif %}

--- a/src/semra/templates/utils.html
+++ b/src/semra/templates/utils.html
@@ -12,7 +12,7 @@
     {%- for curie, predicate, subject_curie, subject_name, target_curie, target_name in mappings -%}
     <tr>
         <td>
-            <a href="{{ url_for('view_mapping', curie=curie) }}">
+            <a href="{{ url_for('.view_mapping', curie=curie) }}">
                 <code>{{ curie[14:22]}}</code>
             </a>
         </td>

--- a/src/semra/web/__init__.py
+++ b/src/semra/web/__init__.py
@@ -1,0 +1,1 @@
+"""Web components."""

--- a/src/semra/web/fastapi_components.py
+++ b/src/semra/web/fastapi_components.py
@@ -6,11 +6,10 @@ from typing import Annotated
 
 import fastapi
 import networkx as nx
-from curies import Reference
 from fastapi import HTTPException, Path, Query
 from fastapi.responses import JSONResponse
 
-from semra import Evidence, Mapping, MappingSet
+from semra import Evidence, Mapping, MappingSet, Reference
 from semra.client import BaseClient
 from semra.web.shared import EXAMPLE_CONCEPTS
 
@@ -47,6 +46,8 @@ def get_concept_cytoscape(
 ) -> JSONResponse:
     """Get the mapping graph surrounding the concept as a Cytoscape.js JSON object."""
     graph = client.get_connected_component_graph(curie)
+    if graph is None:
+        raise HTTPException(status_code=404, detail=f"concept not found: {curie}")
     cytoscape_json = nx.cytoscape_data(graph)["elements"]
     return JSONResponse(cytoscape_json)
 
@@ -62,7 +63,10 @@ def get_exact_matches(
     ),
 ) -> list[Reference]:
     """Get the exact matches to the concept."""
-    return list(client.get_exact_matches(curie, max_distance=max_distance))
+    rv = client.get_exact_matches(curie, max_distance=max_distance)
+    if rv is None:
+        raise HTTPException(status_code=404, detail="concept not found")
+    return list(rv)
 
 
 @api_router.get("/mapping/{mapping_id}", response_model=Mapping)

--- a/src/semra/web/fastapi_components.py
+++ b/src/semra/web/fastapi_components.py
@@ -1,0 +1,97 @@
+"""FastAPI parts."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import fastapi
+import networkx as nx
+from curies import Reference
+from fastapi import HTTPException, Path, Query
+from fastapi.responses import JSONResponse
+
+from semra import Evidence, Mapping, MappingSet
+from semra.client import BaseClient
+from semra.web.shared import EXAMPLE_CONCEPTS
+
+__all__ = ["api_router"]
+
+api_router = fastapi.APIRouter(prefix="/api")
+
+
+def _fastapi_get_client(request: fastapi.Request) -> BaseClient:
+    return request.app.state.client  # type:ignore
+
+
+AnnotatedClient = Annotated[BaseClient, fastapi.Depends(_fastapi_get_client)]
+
+
+@api_router.get("/evidence/{evidence_id}", response_model=Evidence)
+def get_evidence(
+    client: AnnotatedClient,
+    evidence_id: str = Path(description="An evidence's MD5 hex digest."),
+) -> Evidence:
+    """Get an evidence by its MD5 hex digest."""
+    rv = client.get_evidence(evidence_id)
+    if rv is None:
+        raise HTTPException(status_code=404, detail="evidence not found")
+    return rv
+
+
+@api_router.get("/cytoscape/{curie}")
+def get_concept_cytoscape(
+    client: AnnotatedClient,
+    curie: str = Path(
+        description="the compact URI (CURIE) for a concept", examples=EXAMPLE_CONCEPTS
+    ),
+) -> JSONResponse:
+    """Get the mapping graph surrounding the concept as a Cytoscape.js JSON object."""
+    graph = client.get_connected_component_graph(curie)
+    cytoscape_json = nx.cytoscape_data(graph)["elements"]
+    return JSONResponse(cytoscape_json)
+
+
+@api_router.get("/exact/{curie}", response_model=list[Reference])
+def get_exact_matches(
+    client: AnnotatedClient,
+    curie: str = Path(
+        description="the compact URI (CURIE) for a concept", examples=EXAMPLE_CONCEPTS
+    ),
+    max_distance: int = Query(
+        None, description="the distance in the mapping graph to traverse. Defaults to 7"
+    ),
+) -> list[Reference]:
+    """Get the exact matches to the concept."""
+    return list(client.get_exact_matches(curie, max_distance=max_distance))
+
+
+@api_router.get("/mapping/{mapping_id}", response_model=Mapping)
+def get_mapping(
+    client: AnnotatedClient,
+    mapping_id: str = Path(description="A mapping's MD5 hex digest."),
+) -> Mapping:
+    """Get the mapping by its MD5 hex digest."""
+    mapping = client.get_mapping(mapping_id)
+    if mapping is None:
+        raise HTTPException(status_code=404, detail="mapping not found")
+    return mapping
+
+
+@api_router.get("/mapping_set/{mapping_set_id}", response_model=MappingSet)
+def get_mapping_set(
+    client: AnnotatedClient,
+    mapping_set_id: str = Path(
+        description="A mapping set's MD5 hex digest.", examples=["7831d5bc95698099fb6471667e5282cd"]
+    ),
+) -> MappingSet:
+    """Get a mapping set by its MD5 hex digest."""
+    mapping_set = client.get_mapping_set(mapping_set_id)
+    if mapping_set is None:
+        raise HTTPException(status_code=404, detail="mapping set not found")
+    return mapping_set
+
+
+@api_router.get("/mapping_set/", response_model=list[MappingSet])
+def get_mapping_sets(client: AnnotatedClient) -> list[MappingSet]:
+    """Get all mapping sets."""
+    return client.get_mapping_sets()

--- a/src/semra/web/flask_components.py
+++ b/src/semra/web/flask_components.py
@@ -1,0 +1,161 @@
+"""Flask parts."""
+
+from __future__ import annotations
+
+import typing as t
+from typing import cast
+
+import bioregistry
+import flask
+import werkzeug
+from curies import Reference
+from flask import Blueprint, current_app, render_template
+
+from semra.client import BaseClient
+from semra.web.shared import State, _figure_number
+
+__all__ = [
+    "flask_blueprint",
+]
+
+flask_blueprint = Blueprint("ui", __name__)
+
+
+# TODO use replaced by relationship for rewiring
+
+
+@flask_blueprint.get("/")
+def home() -> str:
+    """View the homepage, with a dashboard for several statistics over the database."""
+    # TODO
+    #  1. Mapping with most evidences
+    #  7. Nodes with equivalent entity sharing its prefix
+    state = _flask_get_state()
+    client = _flask_get_client()
+    return render_template(
+        "home.html",
+        example_mappings=state.summary.example_mappings,
+        predicate_counter=state.summary.PREDICATE_COUNTER,
+        mapping_set_counter=state.summary.MAPPING_SET_COUNTER,
+        node_counter=state.summary.NODE_COUNTER,
+        mapping_sets=client.get_mapping_sets(),
+        format_number=_figure_number,
+        justification_counter=state.summary.JUSTIFICATION_COUNTER,
+        evidence_type_counter=state.summary.EVIDENCE_TYPE_COUNTER,
+        prefix_counter=state.summary.PREFIX_COUNTER,
+        author_counter=state.summary.AUTHOR_COUNTER,
+        high_matches_counter=state.summary.HIGH_MATCHES_COUNTER,
+    )
+
+
+@flask_blueprint.get("/mapping/<curie>")
+def view_mapping(curie: str) -> str:
+    """View a mapping."""
+    m = _flask_get_client().get_mapping(curie)
+    return render_template("mapping.html", mapping=m)
+
+
+@flask_blueprint.get("/concept/<curie>")
+def view_concept(curie: str) -> str:
+    """View a concept."""
+    reference = Reference.from_curie(curie)
+    client = _flask_get_client()
+    name = client.get_concept_name(curie)
+    # TODO include evidence for each for better debugging
+    exact_matches = client.get_exact_matches(curie)
+    # TODO when showing equivalence between two entities from same
+    #  namespace, suggest curating a replaced by relation
+    return render_template(
+        "concept.html",
+        reference=reference,
+        curie=curie,
+        name=name,
+        exact_matches=exact_matches,
+        has_biomappings=_flask_get_biomappings_hash() is not None,
+        false_mapping_index=_flask_get_false_mapping_index(),
+    )
+
+
+@flask_blueprint.get("/concept/<source>/invalidate/<target>")
+def mark_exact_incorrect(source: str, target: str) -> werkzeug.Response:
+    """Add a negative relationship to biomappings."""
+    if _flask_get_biomappings_hash() is None:
+        flask.flash("Can't interact with biomappings", category="error")
+        return flask.redirect(flask.url_for(view_concept.__name__, curie=source))
+
+    client = _flask_get_client()
+
+    import biomappings.resources
+    from biomappings.wsgi import _manual_source
+
+    source_reference = Reference.from_curie(source)
+    target_reference = Reference.from_curie(target)
+
+    mapping: dict[str, str] = {
+        "source prefix": source_reference.prefix,
+        "source identifier": source_reference.identifier,
+        "target prefix": target_reference.prefix,
+        "target identifier": target_reference.identifier,
+        "relation": "skos:exactMatch",
+        "type": "semapv:ManualMappingCuration",
+        "source": _manual_source(),
+        "prediction_type": "",
+        "prediction_source": "semra",
+        "prediction_confidence": "",
+    }
+    if source_name := client.get_concept_name(source):
+        mapping["source name"] = source_name
+    if target_name := client.get_concept_name(target):
+        mapping["target name"] = target_name
+
+    mapping = biomappings.resources._standardize_mapping(mapping)
+    biomappings.resources.append_false_mappings([mapping])
+    _index_mapping(_flask_get_false_mapping_index(), mapping)
+
+    flask.flash("Appended negative mapping")
+    return flask.redirect(flask.url_for(view_concept.__name__, curie=source))
+
+
+@flask_blueprint.get("/mapping_set/<mapping_set_id>")
+def view_mapping_set(mapping_set_id: str) -> str:
+    """View a mapping set by its ID."""
+    client = _flask_get_client()
+    mapping_set = client.get_mapping_set(mapping_set_id)
+    examples = client.sample_mappings_from_set(mapping_set_id, n=10)
+    return render_template(
+        "mapping_set.html",
+        mapping_set=mapping_set,
+        mapping_examples=examples,
+    )
+
+
+def _flask_get_state() -> State:
+    """Get the state for the flask app."""
+    return cast(State, current_app.extensions["semra"])
+
+
+def _flask_get_client() -> BaseClient:
+    """Get a client for the flask app."""
+    return _flask_get_state().client
+
+
+def _flask_get_biomappings_hash() -> str | None:
+    """Get the biomappings hash for the flask app."""
+    return _flask_get_state().biomappings_hash
+
+
+def _flask_get_false_mapping_index() -> set[tuple[str, str]]:
+    """Get a false mapping_index for the flask app."""
+    return _flask_get_state().false_mapping_index
+
+
+def _index_mapping(mapping_index: set[tuple[str, str]], mapping_dict: t.Mapping[str, str]) -> None:
+    if mapping_dict["relation"] != "skos:exactMatch":
+        return
+    sp, si = mapping_dict["source prefix"], mapping_dict["source identifier"]
+    tp, ti = mapping_dict["target prefix"], mapping_dict["target identifier"]
+    si = bioregistry.standardize_identifier(sp, si)
+    ti = bioregistry.standardize_identifier(tp, ti)
+    s, t = f"{sp}:{si}", f"{tp}:{ti}"
+    mapping_index.add((s, t))
+    mapping_index.add((t, s))

--- a/src/semra/web/flask_components.py
+++ b/src/semra/web/flask_components.py
@@ -33,13 +33,14 @@ def home() -> str:
     #  7. Nodes with equivalent entity sharing its prefix
     state = _flask_get_state()
     client = _flask_get_client()
+    mapping_sets = client.get_mapping_sets()
     return render_template(
         "home.html",
         example_mappings=state.summary.example_mappings,
         predicate_counter=state.summary.PREDICATE_COUNTER,
         mapping_set_counter=state.summary.MAPPING_SET_COUNTER,
         node_counter=state.summary.NODE_COUNTER,
-        mapping_sets=client.get_mapping_sets(),
+        mapping_sets=mapping_sets,
         format_number=_figure_number,
         justification_counter=state.summary.JUSTIFICATION_COUNTER,
         evidence_type_counter=state.summary.EVIDENCE_TYPE_COUNTER,

--- a/src/semra/web/flask_components.py
+++ b/src/semra/web/flask_components.py
@@ -16,6 +16,7 @@ from semra.web.shared import State, _figure_number
 
 __all__ = [
     "flask_blueprint",
+    "index_biomapping",
 ]
 
 flask_blueprint = Blueprint("ui", __name__)
@@ -110,7 +111,7 @@ def mark_exact_incorrect(source: str, target: str) -> werkzeug.Response:
 
     mapping = biomappings.resources._standardize_mapping(mapping)
     biomappings.resources.append_false_mappings([mapping])
-    _index_mapping(_flask_get_false_mapping_index(), mapping)
+    index_biomapping(_flask_get_false_mapping_index(), mapping)
 
     flask.flash("Appended negative mapping")
     return flask.redirect(flask.url_for(view_concept.__name__, curie=source))
@@ -149,7 +150,10 @@ def _flask_get_false_mapping_index() -> set[tuple[str, str]]:
     return _flask_get_state().false_mapping_index
 
 
-def _index_mapping(mapping_index: set[tuple[str, str]], mapping_dict: t.Mapping[str, str]) -> None:
+def index_biomapping(
+    mapping_index: set[tuple[str, str]], mapping_dict: t.Mapping[str, str]
+) -> None:
+    """Index a mapping from biomappings."""
     if mapping_dict["relation"] != "skos:exactMatch":
         return
     sp, si = mapping_dict["source prefix"], mapping_dict["source identifier"]

--- a/src/semra/web/shared.py
+++ b/src/semra/web/shared.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from semra.client import BaseClient, ExampleMapping, FullSummary
 
@@ -20,8 +20,8 @@ class State:
 
     client: BaseClient
     summary: FullSummary
-    biomappings_hash: str | None
-    false_mapping_index: set[tuple[str, str]]
+    biomappings_hash: str | None = None
+    false_mapping_index: set[tuple[str, str]] = field(default_factory=set)
 
     def example_mappings(self) -> list[ExampleMapping]:
         """Extract example mappings."""

--- a/src/semra/web/shared.py
+++ b/src/semra/web/shared.py
@@ -1,0 +1,45 @@
+"""Shared functionality across flask and fastapi."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from semra.client import BaseClient, ExampleMapping, FullSummary
+
+__all__ = [
+    "EXAMPLE_CONCEPTS",
+    "State",
+]
+
+EXAMPLE_CONCEPTS = ["efo:0002142"]
+
+
+@dataclass
+class State:
+    """Represents application state."""
+
+    client: BaseClient
+    summary: FullSummary
+    biomappings_hash: str | None
+    false_mapping_index: set[tuple[str, str]]
+
+    def example_mappings(self) -> list[ExampleMapping]:
+        """Extract example mappings."""
+        return self.summary.example_mappings
+
+
+def _figure_number(n: int) -> tuple[int | float, str]:
+    if n > 1_000_000:
+        lead = n / 1_000_000
+        if lead < 10:
+            return round(lead, 1), "M"
+        else:
+            return round(lead), "M"
+    if n > 1_000:
+        lead = n / 1_000
+        if lead < 10:
+            return round(lead, 1), "K"
+        else:
+            return round(lead), "K"
+    else:
+        return n, ""

--- a/src/semra/wsgi.py
+++ b/src/semra/wsgi.py
@@ -19,35 +19,42 @@ from semra.web.shared import State
 # docstr-coverage:excused `overload`
 @overload
 def get_app(
-    *, client: BaseClient | None = ..., return_flask: Literal[True] = True
+    *,
+    client: BaseClient | None = ...,
+    return_flask: Literal[True] = True,
+    use_biomappings: bool = ...,
 ) -> tuple[Flask, fastapi.FastAPI]: ...
 
 
 # docstr-coverage:excused `overload`
 @overload
 def get_app(
-    *, client: BaseClient | None = ..., return_flask: Literal[False] = False
+    *,
+    client: BaseClient | None = ...,
+    return_flask: Literal[False] = False,
+    use_biomappings: bool = ...,
 ) -> fastapi.FastAPI: ...
 
 
 def get_app(
-    *, client: BaseClient | None = None, return_flask: bool = False
+    *, client: BaseClient | None = None, return_flask: bool = False, use_biomappings: bool = True
 ) -> fastapi.FastAPI | tuple[Flask, fastapi.FastAPI]:
     """Get the SeMRA FastAPI app."""
     if client is None:
         client = Neo4jClient()
 
-    biomappings_git_hash: str | None
+    biomappings_git_hash: str | None = None
     false_mapping_index: set[tuple[str, str]] = set()
 
-    try:
-        import biomappings.utils
-    except ImportError:
-        biomappings_git_hash = None
-    else:
-        biomappings_git_hash = biomappings.utils.get_git_hash()
-        for m in biomappings.load_false_mappings():
-            index_biomapping(false_mapping_index, m)
+    if use_biomappings:
+        try:
+            import biomappings.utils
+        except ImportError:
+            pass
+        else:
+            biomappings_git_hash = biomappings.utils.get_git_hash()
+            for m in biomappings.load_false_mappings():
+                index_biomapping(false_mapping_index, m)
 
     state = State(
         client=client,

--- a/src/semra/wsgi.py
+++ b/src/semra/wsgi.py
@@ -12,7 +12,7 @@ from starlette.middleware.wsgi import WSGIMiddleware
 
 from semra.client import BaseClient, Neo4jClient
 from semra.web.fastapi_components import api_router
-from semra.web.flask_components import _index_mapping, flask_blueprint
+from semra.web.flask_components import flask_blueprint, index_biomapping
 from semra.web.shared import State
 
 
@@ -47,7 +47,7 @@ def get_app(
     else:
         biomappings_git_hash = biomappings.utils.get_git_hash()
         for m in biomappings.load_false_mappings():
-            _index_mapping(false_mapping_index, m)
+            index_biomapping(false_mapping_index, m)
 
     state = State(
         client=client,

--- a/src/semra/wsgi.py
+++ b/src/semra/wsgi.py
@@ -3,279 +3,17 @@
 from __future__ import annotations
 
 import os
-import typing as t
-from dataclasses import dataclass
-from typing import Annotated, Literal, cast, overload
+from typing import Literal, overload
 
-import bioregistry
 import fastapi
-import flask
-import networkx as nx
-import werkzeug
-from curies import Reference
-from fastapi import HTTPException, Path, Query
-from fastapi.responses import JSONResponse
-from flask import Blueprint, Flask, current_app, render_template
+from flask import Flask
 from flask_bootstrap import Bootstrap5
 from starlette.middleware.wsgi import WSGIMiddleware
 
-from semra import Evidence, Mapping, MappingSet
-from semra.client import BaseClient, ExampleMapping, FullSummary, Neo4jClient
-
-EXAMPLE_CONCEPTS = ["efo:0002142"]
-
-
-def _index_mapping(mapping_index: set[tuple[str, str]], mapping_dict: t.Mapping[str, str]) -> None:
-    if mapping_dict["relation"] != "skos:exactMatch":
-        return
-    sp, si = mapping_dict["source prefix"], mapping_dict["source identifier"]
-    tp, ti = mapping_dict["target prefix"], mapping_dict["target identifier"]
-    si = bioregistry.standardize_identifier(sp, si)
-    ti = bioregistry.standardize_identifier(tp, ti)
-    s, t = f"{sp}:{si}", f"{tp}:{ti}"
-    mapping_index.add((s, t))
-    mapping_index.add((t, s))
-
-
-try:
-    import biomappings.utils
-except ImportError:
-    BIOMAPPINGS_GIT_HASH = None
-    false_mapping_index: set[tuple[str, str]] = set()
-else:
-    BIOMAPPINGS_GIT_HASH = biomappings.utils.get_git_hash()
-    false_mapping_index = set()
-    # for m in biomappings.load_false_mappings():
-    #    _index_mapping(false_mapping_index, m)
-
-api_router = fastapi.APIRouter(prefix="/api")
-
-flask_blueprint = Blueprint("ui", __name__)
-
-
-# TODO use replaced by relationship for rewiring
-
-
-def _figure_number(n: int) -> tuple[int | float, str]:
-    if n > 1_000_000:
-        lead = n / 1_000_000
-        if lead < 10:
-            return round(lead, 1), "M"
-        else:
-            return round(lead), "M"
-    if n > 1_000:
-        lead = n / 1_000
-        if lead < 10:
-            return round(lead, 1), "K"
-        else:
-            return round(lead), "K"
-    else:
-        return n, ""
-
-
-@flask_blueprint.get("/")
-def home() -> str:
-    """View the homepage, with a dashboard for several statistics over the database."""
-    # TODO
-    #  1. Mapping with most evidences
-    #  7. Nodes with equivalent entity sharing its prefix
-    state = _flask_get_state()
-    client = _flask_get_client()
-    return render_template(
-        "home.html",
-        example_mappings=state.summary.example_mappings,
-        predicate_counter=state.summary.PREDICATE_COUNTER,
-        mapping_set_counter=state.summary.MAPPING_SET_COUNTER,
-        node_counter=state.summary.NODE_COUNTER,
-        mapping_sets=client.get_mapping_sets(),
-        format_number=_figure_number,
-        justification_counter=state.summary.JUSTIFICATION_COUNTER,
-        evidence_type_counter=state.summary.EVIDENCE_TYPE_COUNTER,
-        prefix_counter=state.summary.PREFIX_COUNTER,
-        author_counter=state.summary.AUTHOR_COUNTER,
-        high_matches_counter=state.summary.HIGH_MATCHES_COUNTER,
-    )
-
-
-@flask_blueprint.get("/mapping/<curie>")
-def view_mapping(curie: str) -> str:
-    """View a mapping."""
-    m = _flask_get_client().get_mapping(curie)
-    return render_template("mapping.html", mapping=m)
-
-
-@flask_blueprint.get("/concept/<curie>")
-def view_concept(curie: str) -> str:
-    """View a concept."""
-    reference = Reference.from_curie(curie)
-    client = _flask_get_client()
-    name = client.get_concept_name(curie)
-    # TODO include evidence for each for better debugging
-    exact_matches = client.get_exact_matches(curie)
-    # TODO when showing equivalence between two entities from same
-    #  namespace, suggest curating a replaced by relation
-    return render_template(
-        "concept.html",
-        reference=reference,
-        curie=curie,
-        name=name,
-        exact_matches=exact_matches,
-        has_biomappings=BIOMAPPINGS_GIT_HASH is not None,
-        false_mapping_index=false_mapping_index,
-    )
-
-
-@flask_blueprint.get("/concept/<source>/invalidate/<target>")
-def mark_exact_incorrect(source: str, target: str) -> werkzeug.Response:
-    """Add a negative relationship to biomappings."""
-    if not BIOMAPPINGS_GIT_HASH:
-        flask.flash("Can't interact with biomappings", category="error")
-        return flask.redirect(flask.url_for(view_concept.__name__, curie=source))
-
-    client = _flask_get_client()
-
-    import biomappings.resources
-    from biomappings.wsgi import _manual_source
-
-    source_reference = Reference.from_curie(source)
-    target_reference = Reference.from_curie(target)
-
-    mapping: dict[str, str] = {
-        "source prefix": source_reference.prefix,
-        "source identifier": source_reference.identifier,
-        "target prefix": target_reference.prefix,
-        "target identifier": target_reference.identifier,
-        "relation": "skos:exactMatch",
-        "type": "semapv:ManualMappingCuration",
-        "source": _manual_source(),
-        "prediction_type": "",
-        "prediction_source": "semra",
-        "prediction_confidence": "",
-    }
-    if source_name := client.get_concept_name(source):
-        mapping["source name"] = source_name
-    if target_name := client.get_concept_name(target):
-        mapping["target name"] = target_name
-
-    mapping = biomappings.resources._standardize_mapping(mapping)
-    biomappings.resources.append_false_mappings([mapping])
-    _index_mapping(false_mapping_index, mapping)
-
-    flask.flash("Appended negative mapping")
-    return flask.redirect(flask.url_for(view_concept.__name__, curie=source))
-
-
-@flask_blueprint.get("/mapping_set/<mapping_set_id>")
-def view_mapping_set(mapping_set_id: str) -> str:
-    """View a mapping set by its ID."""
-    client = _flask_get_client()
-    mapping_set = client.get_mapping_set(mapping_set_id)
-    examples = client.sample_mappings_from_set(mapping_set_id, n=10)
-    return render_template(
-        "mapping_set.html",
-        mapping_set=mapping_set,
-        mapping_examples=examples,
-    )
-
-
-def _fastapi_get_client(request: fastapi.Request) -> BaseClient:
-    return request.app.state.client  # type:ignore
-
-
-AnnotatedClient = Annotated[BaseClient, fastapi.Depends(_fastapi_get_client)]
-
-
-@api_router.get("/evidence/{evidence_id}", response_model=Evidence)
-def get_evidence(
-    client: AnnotatedClient,
-    evidence_id: str = Path(description="An evidence's MD5 hex digest."),
-) -> Evidence:
-    """Get an evidence by its MD5 hex digest."""
-    rv = client.get_evidence(evidence_id)
-    if rv is None:
-        raise HTTPException(status_code=404, detail="evidence not found")
-    return rv
-
-
-@api_router.get("/cytoscape/{curie}")
-def get_concept_cytoscape(
-    client: AnnotatedClient,
-    curie: str = Path(
-        description="the compact URI (CURIE) for a concept", examples=EXAMPLE_CONCEPTS
-    ),
-) -> JSONResponse:
-    """Get the mapping graph surrounding the concept as a Cytoscape.js JSON object."""
-    graph = client.get_connected_component_graph(curie)
-    cytoscape_json = nx.cytoscape_data(graph)["elements"]
-    return JSONResponse(cytoscape_json)
-
-
-@api_router.get("/exact/{curie}", response_model=list[Reference])
-def get_exact_matches(
-    client: AnnotatedClient,
-    curie: str = Path(
-        description="the compact URI (CURIE) for a concept", examples=EXAMPLE_CONCEPTS
-    ),
-    max_distance: int = Query(
-        None, description="the distance in the mapping graph to traverse. Defaults to 7"
-    ),
-) -> list[Reference]:
-    """Get the exact matches to the concept."""
-    return list(client.get_exact_matches(curie, max_distance=max_distance))
-
-
-@api_router.get("/mapping/{mapping_id}", response_model=Mapping)
-def get_mapping(
-    client: AnnotatedClient,
-    mapping_id: str = Path(description="A mapping's MD5 hex digest."),
-) -> Mapping:
-    """Get the mapping by its MD5 hex digest."""
-    mapping = client.get_mapping(mapping_id)
-    if mapping is None:
-        raise HTTPException(status_code=404, detail="mapping not found")
-    return mapping
-
-
-@api_router.get("/mapping_set/{mapping_set_id}", response_model=MappingSet)
-def get_mapping_set(
-    client: AnnotatedClient,
-    mapping_set_id: str = Path(
-        description="A mapping set's MD5 hex digest.", examples=["7831d5bc95698099fb6471667e5282cd"]
-    ),
-) -> MappingSet:
-    """Get a mapping set by its MD5 hex digest."""
-    mapping_set = client.get_mapping_set(mapping_set_id)
-    if mapping_set is None:
-        raise HTTPException(status_code=404, detail="mapping set not found")
-    return mapping_set
-
-
-@api_router.get("/mapping_set/", response_model=list[MappingSet])
-def get_mapping_sets(client: AnnotatedClient) -> list[MappingSet]:
-    """Get all mapping sets."""
-    return client.get_mapping_sets()
-
-
-@dataclass
-class State:
-    """Represents application state."""
-
-    client: BaseClient
-    summary: FullSummary
-
-    def example_mappings(self) -> list[ExampleMapping]:
-        """Extract example mappings."""
-        return self.summary.example_mappings
-
-
-def _flask_get_state() -> State:
-    """Get the state for the flask app."""
-    return cast(State, current_app.extensions["semra"])
-
-
-def _flask_get_client() -> BaseClient:
-    """Get a client for the flask app."""
-    return _flask_get_state().client
+from semra.client import BaseClient, Neo4jClient
+from semra.web.fastapi_components import api_router
+from semra.web.flask_components import _index_mapping, flask_blueprint
+from semra.web.shared import State
 
 
 # docstr-coverage:excused `overload`
@@ -299,9 +37,23 @@ def get_app(
     if client is None:
         client = Neo4jClient()
 
+    biomappings_git_hash: str | None
+    false_mapping_index: set[tuple[str, str]] = set()
+
+    try:
+        import biomappings.utils
+    except ImportError:
+        biomappings_git_hash = None
+    else:
+        biomappings_git_hash = biomappings.utils.get_git_hash()
+        for m in biomappings.load_false_mappings():
+            _index_mapping(false_mapping_index, m)
+
     state = State(
         client=client,
         summary=client.get_full_summary(),
+        false_mapping_index=false_mapping_index,
+        biomappings_hash=biomappings_git_hash,
     )
 
     flask_app = Flask(__name__)

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -6,5 +6,13 @@ a1_curie = "CHEBI:10084"  # Xylopinine
 a2_curie = "CHEBI:10100"  # zafirlukast
 b1_curie = "mesh:C453820"  # xylopinine
 b2_curie = "mesh:C062735"  # zafirlukast
-a1, a2 = Reference.from_curie(a1_curie.lower()), Reference.from_curie(a2_curie.lower())
-b1, b2 = Reference.from_curie(b1_curie), Reference.from_curie(b2_curie)
+a1, a2 = (
+    Reference.from_curie(a1_curie.lower(), name="Xylopinine"),
+    Reference.from_curie(a2_curie.lower(), name="zafirlukast"),
+)
+b1, b2 = (
+    Reference.from_curie(b1_curie, name="xylopinine"),
+    Reference.from_curie(b2_curie, name="zafirlukast"),
+)
+
+TEST_CURIES = {a1, a2, b1, b2}

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4,15 +4,24 @@ import unittest
 
 from starlette.testclient import TestClient
 
-from semra import EXACT_MATCH, UNSPECIFIED_MAPPING, Evidence, Mapping, MappingSet, SimpleEvidence
+from semra import (
+    EXACT_MATCH,
+    UNSPECIFIED_MAPPING,
+    Evidence,
+    Mapping,
+    MappingSet,
+    Reference,
+    SimpleEvidence,
+)
 from semra.client import BaseClient, FullSummary, ReferenceHint
 from semra.wsgi import get_app
 from tests.constants import a1, a2, b1, b2
 
+MS1 = MappingSet(
+    name="Test Mapping Set",
+)
 E1 = SimpleEvidence(
-    mapping_set=MappingSet(
-        name="Test Mapping Set",
-    ),
+    mapping_set=MS1,
     justification=UNSPECIFIED_MAPPING,
 )
 M1 = Mapping(subject=a1, predicate=EXACT_MATCH, object=b1, evidence=[E1])
@@ -53,3 +62,31 @@ class TestApp(unittest.TestCase):
 
         res2 = test_client.get(f"/api/evidence/{E1_M2_REFERENCE.curie}")
         self.assertEqual(404, res2.status_code)
+
+        # Test mapping set API
+        res3 = test_client.get(f"/api/mapping_set/{MS1.curie}")
+        self.assertEqual(200, res1.status_code)
+        self.assertEqual(MS1, MappingSet.model_validate(res3.json()))
+
+        res4 = test_client.get("/api/mapping_set/abcdef")
+        self.assertEqual(404, res4.status_code)
+
+        res5 = test_client.get("/api/mapping_set/")
+        self.assertEqual(200, res1.status_code)
+        self.assertEqual([MS1], [MappingSet.model_validate(r) for r in res5.json()])
+
+        # Test mapping API
+        res6 = test_client.get(f"/api/mapping/{M1.curie}")
+        self.assertEqual(200, res1.status_code)
+        self.assertEqual(M1, Mapping.model_validate(res6.json()))
+
+        res7 = test_client.get("/api/mapping/abcdef")
+        self.assertEqual(404, res7.status_code)
+
+        # Test concept API
+        res8 = test_client.get(f"/api/concept/{a1.curie}")
+        self.assertEqual(200, res1.status_code)
+        self.assertEqual(a1, Reference.model_validate(res8.json()))
+
+        res9 = test_client.get("/api/concept/abcasdef")
+        self.assertEqual(404, res9.status_code)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,55 @@
+"""Test the app."""
+
+import unittest
+
+from starlette.testclient import TestClient
+
+from semra import EXACT_MATCH, UNSPECIFIED_MAPPING, Evidence, Mapping, MappingSet, SimpleEvidence
+from semra.client import BaseClient, FullSummary, ReferenceHint
+from semra.wsgi import get_app
+from tests.constants import a1, a2, b1, b2
+
+E1 = SimpleEvidence(
+    mapping_set=MappingSet(
+        name="Test Mapping Set",
+    ),
+    justification=UNSPECIFIED_MAPPING,
+)
+M1 = Mapping(subject=a1, predicate=EXACT_MATCH, object=b1, evidence=[E1])
+M2 = Mapping(subject=a2, predicate=EXACT_MATCH, object=b2, evidence=[E1])
+TEST_MAPPINGS = [M1, M2]
+E1_M1_REFERENCE = E1.get_reference(triple=M1)
+E1_M2_REFERENCE = E1.get_reference(triple=M2)
+
+
+class MockClient(BaseClient):
+    """A mock client."""
+
+    def get_evidence(self, curie: ReferenceHint) -> Evidence:
+        """Get an evidence."""
+        if curie == E1_M1_REFERENCE.curie:
+            return E1
+        return None
+
+    def get_full_summary(self) -> FullSummary:
+        """Get an empty summary."""
+        return FullSummary()
+
+
+class TestApp(unittest.TestCase):
+    """Test the app."""
+
+    def test_app(self) -> None:
+        """Test the app."""
+        client = MockClient()
+        _flask_app, fastapi_app = get_app(client=client, return_flask=True)
+
+        test_client = TestClient(fastapi_app)
+
+        # Test evidence API
+        res1 = test_client.get(f"/api/evidence/{E1_M1_REFERENCE.curie}")
+        self.assertEqual(200, res1.status_code)
+        self.assertEqual(E1, SimpleEvidence.model_validate(res1.json()))
+
+        res2 = test_client.get(f"/api/evidence/{E1_M2_REFERENCE.curie}")
+        self.assertEqual(404, res2.status_code)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -18,14 +18,14 @@ E1 = SimpleEvidence(
 M1 = Mapping(subject=a1, predicate=EXACT_MATCH, object=b1, evidence=[E1])
 M2 = Mapping(subject=a2, predicate=EXACT_MATCH, object=b2, evidence=[E1])
 TEST_MAPPINGS = [M1, M2]
-E1_M1_REFERENCE = E1.get_reference(triple=M1)
-E1_M2_REFERENCE = E1.get_reference(triple=M2)
+E1_M1_REFERENCE = E1.get_reference(M1)
+E1_M2_REFERENCE = E1.get_reference(M2)
 
 
 class MockClient(BaseClient):
     """A mock client."""
 
-    def get_evidence(self, curie: ReferenceHint) -> Evidence:
+    def get_evidence(self, curie: ReferenceHint) -> Evidence | None:
         """Get an evidence."""
         if curie == E1_M1_REFERENCE.curie:
             return E1

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ commands =
 extras =
     # See the [project.optional-dependencies] entry in pyproject.toml for "tests"
     tests
+    web
 
 [testenv:coverage-clean]
 description = Remove testing coverage artifacts.


### PR DESCRIPTION
This PR abstracts the neo4j client into a base client that can be mocked in tests. This PR then adds tests for the fastapi and flask endpoints.

Future work:

1. More detailed testing of summary components
2. How to test the cytoscape component output? Unify the cytoscape graph model with the other code that constructs these
3. Testing of the Neo4j client itself (requires mocking neo4j / having a test instance)

At least this one catches a few issues in the templates