### PR TITLE
Mount files in docker, use uv, make python configurable

### DIFF
--- a/src/semra/io/neo4j_io.py
+++ b/src/semra/io/neo4j_io.py
@@ -100,6 +100,7 @@ EVIDENCE_NODES_FILENAME = "evidence_nodes.tsv"
 MAPPING_SET_NODES_FILENAME = "mapping_set_nodes.tsv"
 MAPPING_EDGES_FILENAME = "mapping_edges.tsv"
 EDGES_FILENAME = "edges.tsv"
+PYTHON = "python3.12"
 
 
 def write_neo4j(
@@ -281,7 +282,9 @@ def write_neo4j(
                     )
 
     startup_path = directory.joinpath(startup_script_name)
-    startup_path.write_text(STARTUP_TEMPLATE.render())
+    startup_path.write_text(STARTUP_TEMPLATE.render(
+        python=PYTHON,
+    ))
 
     if compress == "after":
         node_names = [(label, gzip_path(path).relative_to(directory)) for label, path in node_paths]
@@ -296,11 +299,15 @@ def write_neo4j(
             node_names=node_names,
             edge_names=edge_names,
             pip_install=pip_install,
+            python=PYTHON,
         )
     )
 
     run_path = directory.joinpath(run_script_name)
-    run_path.write_text(RUN_ON_STARTUP_TEMPLATE.render(docker_name=docker_name))
+    run_path.write_text(RUN_ON_STARTUP_TEMPLATE.render(
+        docker_name=docker_name,
+        python=PYTHON,
+    ))
 
     click.secho("Run Neo4j with the following:", fg="green")
     click.secho(f"  cd {run_path.parent.absolute()}")

--- a/src/semra/io/templates/Dockerfile
+++ b/src/semra/io/templates/Dockerfile
@@ -12,23 +12,34 @@ RUN apt-get update && \
 # Install python
 RUN apt-get update && \
     add-apt-repository ppa:deadsnakes/ppa && \
-    apt-get install -y git zip unzip bzip2 gcc pkg-config python3.11 && \
-    curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
+    apt-get install -y git zip unzip bzip2 gcc pkg-config {{ python }}
 
-RUN python3.11 -m pip install "{{ pip_install }}"
+# Security-conscious organizations should package/review uv themselves.
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
-# Add nodes files to the docker image
-{%- for node_type, name in node_names %}
-COPY {{ name }} /sw/{{ name }}
-{%- endfor %}
+# - Silence uv complaining about not being able to use hard links,
+# - tell uv to byte-compile packages for faster application startups,
+# - prevent uv from accidentally downloading isolated Python builds,
+# - pick a Python (use `/usr/bin/python3.12` on uv 0.5.0 and later),
+# - and finally declare `/app` as the target for `uv sync`.
+ENV UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
+    UV_PYTHON_DOWNLOADS=never \
+    UV_PYTHON={{ python }}
 
-# Add edge files to the docker image
-{%- for name in edge_names %}
-COPY {{ name }} /sw/{{ name }}
-{%- endfor %}
+# Install dependencies
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system "{{ pip_install }}"
 
-# Ingest graph content into neo4j
-RUN sed -i 's/#dbms.default_listen_address/dbms.default_listen_address/' /etc/neo4j/neo4j.conf && \
+# Ingest graph content into neo4j. Mount the data
+RUN \
+    {%- for name in edge_names %}
+    --mount=type=bind,source={{ name }},target=/sw/{{ name }} \
+    {%- endfor %}
+    {%- for node_type, name in node_names %}
+    --mount=type=bind,source={{ name }},target=/sw/{{ name }} \
+    {%- endfor %}
+    sed -i 's/#dbms.default_listen_address/dbms.default_listen_address/' /etc/neo4j/neo4j.conf && \
     sed -i 's/#dbms.security.auth_enabled/dbms.security.auth_enabled/' /etc/neo4j/neo4j.conf && \
     neo4j-admin import --delimiter='TAB' --skip-duplicate-nodes=true \
         {%- for name in edge_names %}
@@ -38,8 +49,6 @@ RUN sed -i 's/#dbms.default_listen_address/dbms.default_listen_address/' /etc/ne
         --nodes={{ node_type }}=/sw/{{ name }} \
         {%- endfor %}
         --skip-bad-relationships=true
-
-# TODO remove source files to make the image smaller
 
 COPY startup.sh startup.sh
 ENTRYPOINT ["/bin/bash", "/sw/startup.sh"]

--- a/src/semra/io/templates/run_on_startup.sh
+++ b/src/semra/io/templates/run_on_startup.sh
@@ -3,7 +3,7 @@
 set -x  # Enable command printing
 
 # build the dockerfile
-DOCKER_CLI_HINTS=false docker build --tag {{ docker_name }} .
+DOCKER_CLI_HINTS=false DOCKER_BUILDKIT=1 docker build --tag {{ docker_name }} .
 
 # -t means allocate a pseudo-TTY, necessary to keep it running in the background
 docker run -t --detach -p 7474:7474 -p 7687:7687 -p 8773:8773 --name {{ docker_name }} {{ docker_name }}:latest

--- a/src/semra/io/templates/startup.sh
+++ b/src/semra/io/templates/startup.sh
@@ -11,4 +11,4 @@ do
 done
 
 neo4j status
-python3.11 -m uvicorn --host 0.0.0.0 --port 8773 --factory semra.wsgi:get_app
+{{ python }} -m uvicorn --host 0.0.0.0 --port 8773 --factory semra.wsgi:get_app


### PR DESCRIPTION
- [x] Mount files instead of copying them into image, since neo4j just uses them temporarily
- [x] Use `uv` instead of pip
- [x] Make python version configurable
- [ ] Use newer version of ubuntu
- [ ] Install python via uv