### PR TITLE
Use simpler graph for prioritization of mappings

### DIFF
--- a/src/semra/api.py
+++ b/src/semra/api.py
@@ -530,13 +530,10 @@ def prioritize(mappings: list[Mapping], priority: list[str]) -> list[Mapping]:
     """
     original_mappings = len(mappings)
     mappings_by_subj_obj = {
-        (m.subject.curie, m.object.curie): m for m in mappings
-        if m.predicate == EXACT_MATCH
+        (m.subject.curie, m.object.curie): m for m in mappings if m.predicate == EXACT_MATCH
     }
     # Gather all the references by CURIE
-    references_by_curie = {
-        ref.curie: ref for m in mappings for ref in (m.subject, m.object)
-    }
+    references_by_curie = {ref.curie: ref for m in mappings for ref in (m.subject, m.object)}
 
     exact_mappings = len(mappings)
     priority = _clean_priority_prefixes(priority)
@@ -544,9 +541,7 @@ def prioritize(mappings: list[Mapping], priority: list[str]) -> list[Mapping]:
     graph = to_simple_graph(mappings)
     rv: list[Mapping] = []
     for component in tqdm(nx.connected_components(graph), unit="component", unit_scale=True):
-        component_references = [
-            references_by_curie[curie] for curie in component
-        ]
+        component_references = [references_by_curie[curie] for curie in component]
         o = get_priority_reference(component_references, priority)
         if o is None:
             continue

--- a/src/semra/io/graph.py
+++ b/src/semra/io/graph.py
@@ -16,8 +16,8 @@ __all__ = [
     "from_digraph",
     "from_multidigraph",
     "to_digraph",
-    "to_simple_graph",
     "to_multidigraph",
+    "to_simple_graph",
 ]
 
 #: The key inside the data dictionary for a SeMRA mapping graph
@@ -67,8 +67,7 @@ def to_simple_graph(mappings: t.Iterable[Mapping]) -> nx.Graph:
         the relationships between subject and object CURIEs in mappings.
     """
     graph = nx.Graph()
-    edges = {(mapping.subject.curie, mapping.object.curie)
-             for mapping in mappings}
+    edges = {(mapping.subject.curie, mapping.object.curie) for mapping in mappings}
     graph.add_edges_from(edges)
     return graph
 

--- a/src/semra/io/graph.py
+++ b/src/semra/io/graph.py
@@ -16,6 +16,7 @@ __all__ = [
     "from_digraph",
     "from_multidigraph",
     "to_digraph",
+    "to_simple_graph",
     "to_multidigraph",
 ]
 
@@ -53,6 +54,22 @@ def to_digraph(mappings: t.Iterable[Mapping]) -> nx.DiGraph:
         edges[mapping.subject, mapping.object][mapping.predicate].extend(mapping.evidence)
     for (s, o), data in edges.items():
         graph.add_edge(s, o, **{DIGRAPH_DATA_KEY: data})
+    return graph
+
+
+def to_simple_graph(mappings: t.Iterable[Mapping]) -> nx.Graph:
+    """Return an undirected graph capturing only the structure of mappings.
+
+    :param mappings: An iterable of mappings
+
+    :returns: An undirected graph in which the nodes are simple string CURIEs
+        corresponding to References. The edges are undirected and represent
+        the relationships between subject and object CURIEs in mappings.
+    """
+    graph = nx.Graph()
+    edges = {(mapping.subject.curie, mapping.object.curie)
+             for mapping in mappings}
+    graph.add_edges_from(edges)
     return graph
 
 


### PR DESCRIPTION
Workflows for mapping prioritization have a large memory footprint which is traceable to the construction of a temporary networkx DiGraph used in prioritization. This PR implements a simplified approach to graph construction which uses a minimal undirected graph containing only the necessary structural information for connected component finding, without propagating additional data into the graph. This appears to significantly decrease memory usage, though more detailed unit testing would be useful to make sure there aren't any assumptions changing with this implementation.