### PR TITLE
Add new SSSOM field - record_id

### DIFF
--- a/src/semra/io/io.py
+++ b/src/semra/io/io.py
@@ -555,6 +555,7 @@ def _from_curie(curie: str, *, standardize: bool, name: str | None = None) -> Re
 class SSSOMRow(NamedTuple):
     """A tuple representing a row in a SSSOM TSV file."""
 
+    record_id: str
     subject_id: str
     subject_label: str
     predicate_id: str
@@ -649,6 +650,7 @@ def _get_sssom_row(mapping: Mapping, e: Evidence, fallback_mapping_set_id: str) 
         raise TypeError
 
     return SSSOMRow(
+        record_id=e.get_reference(triple=mapping),
         subject_id=mapping.subject.curie,
         subject_label=mapping.subject.name or "",
         predicate_id=mapping.predicate.curie,


### PR DESCRIPTION
Add output of SSSOM field for record_id which was added in https://github.com/mapping-commons/sssom/pull/452. This field corresponds to an evidence's reference.