### PR TITLE
Improve configurability of mutations

### DIFF
--- a/src/semra/landscape/taxrank.py
+++ b/src/semra/landscape/taxrank.py
@@ -16,6 +16,7 @@ PRIORITY = [
     "ncbitaxon",
     "tdwg.taxonrank",
 ]
+SUBSETS = {"ncbitaxon": [semra.Reference(prefix="ncbitaxon", identifier="taxonomic_rank")]}
 
 CONFIGURATION = semra.Configuration(
     key="taxrank",
@@ -25,6 +26,7 @@ CONFIGURATION = semra.Configuration(
     inputs=[
         semra.Input(prefix="taxrank", source="pyobo", confidence=0.99),
     ],
+    subsets=SUBSETS,
     add_labels=False,
     priority=PRIORITY,
     remove_imprecise=False,

--- a/src/semra/pipeline.py
+++ b/src/semra/pipeline.py
@@ -19,12 +19,12 @@ from typing_extensions import Self
 
 from semra.api import (
     Mutation,
+    apply_mutations,
     assemble_evidences,
     filter_mappings,
     filter_prefixes,
     filter_self_matches,
     filter_subsets,
-    handle_mutations,
     hydrate_subsets,
     keep_prefixes,
     prioritize,
@@ -969,7 +969,7 @@ def process(
         logger.info("Applying mutations")
         before = len(mappings)
         start = time.time()
-        mappings = list(handle_mutations(mappings, mutations, progress=progress))
+        mappings = list(apply_mutations(mappings, mutations, progress=progress))
         _log_diff(before, mappings, verb="Applied mutations", elapsed=time.time() - start)
 
     if upgrade_prefixes and len(upgrade_prefixes) > 1:

--- a/src/semra/pipeline.py
+++ b/src/semra/pipeline.py
@@ -777,10 +777,6 @@ def get_priority_mappings_from_config(
         # click.echo(semra.api.str_source_target_counts(mappings, minimum=20))
         processed_mappings = process(
             raw_mappings,
-            # TODO more configuration of different mutation types
-            upgrade_prefixes=[  # TODO more carefully compile a set of mutations together for applying
-                m.source for m in configuration.mutations
-            ],
             mutations=configuration.mutations,
             remove_prefix_set=configuration.remove_prefixes,
             keep_prefix_set=configuration.keep_prefixes,

--- a/src/semra/pipeline.py
+++ b/src/semra/pipeline.py
@@ -104,6 +104,7 @@ class Mutation(BaseModel):
     """Represents a mutation operation on a mapping set."""
 
     source: str = Field(..., description="The source type")
+    target: str | list[str] | None = Field(None, description="limit mutation to these")
     confidence: float = 1.0
     old: Reference = Field(default=DB_XREF)
     new: Reference = Field(default=EXACT_MATCH)
@@ -387,9 +388,9 @@ class Configuration(BaseModel):
     def get_mappings(
         self,
         *,
-        refresh_raw: bool = False,
-        refresh_processed: bool = False,
-        refresh_source: bool = False,
+        refresh_raw: bool = ...,
+        refresh_processed: bool = ...,
+        refresh_source: bool = ...,
         return_type: Literal[GetMappingReturnType.none] = GetMappingReturnType.none,
     ) -> None: ...
 
@@ -398,9 +399,9 @@ class Configuration(BaseModel):
     def get_mappings(
         self,
         *,
-        refresh_raw: bool = False,
-        refresh_processed: bool = False,
-        refresh_source: bool = False,
+        refresh_raw: bool = ...,
+        refresh_processed: bool = ...,
+        refresh_source: bool = ...,
         return_type: Literal[GetMappingReturnType.all] = GetMappingReturnType.all,
     ) -> MappingPack: ...
 
@@ -409,9 +410,9 @@ class Configuration(BaseModel):
     def get_mappings(
         self,
         *,
-        refresh_raw: bool = False,
-        refresh_processed: bool = False,
-        refresh_source: bool = False,
+        refresh_raw: bool = ...,
+        refresh_processed: bool = ...,
+        refresh_source: bool = ...,
         return_type: Literal[GetMappingReturnType.priority] = GetMappingReturnType.priority,
     ) -> list[Mapping]: ...
 
@@ -777,9 +778,11 @@ def get_priority_mappings_from_config(
         # click.echo(semra.api.str_source_target_counts(mappings, minimum=20))
         processed_mappings = process(
             raw_mappings,
+            # TODO more configuration of different mutation types
             upgrade_prefixes=[  # TODO more carefully compile a set of mutations together for applying
                 m.source for m in configuration.mutations
             ],
+            mutations=configuration.mutations,
             remove_prefix_set=configuration.remove_prefixes,
             keep_prefix_set=configuration.keep_prefixes,
             post_remove_prefixes=configuration.post_remove_prefixes,
@@ -914,6 +917,7 @@ def get_raw_mappings(
 def process(
     mappings: list[Mapping],
     upgrade_prefixes: t.Collection[str] | None = None,
+    mutations: t.Collection[Mutation] | None = None,
     remove_prefix_set: t.Collection[str] | None = None,
     keep_prefix_set: t.Collection[str] | None = None,
     post_remove_prefixes: t.Collection[str] | None = None,
@@ -960,6 +964,9 @@ def process(
     # start = time.time()
     # mappings = filter_self_matches(mappings)
     # _log_diff(before, mappings, verb="Filtered source internal", elapsed=time.time() - start)
+
+    if mutations:
+        raise NotImplementedError
 
     if upgrade_prefixes and len(upgrade_prefixes) > 1:
         logger.info("Inferring mapping upgrades")

--- a/src/semra/summarize.py
+++ b/src/semra/summarize.py
@@ -488,6 +488,10 @@ def draw_counter(
     direction: str = "LR",
 ) -> bytes:
     """Draw a source/target prefix pair counter as a network."""
+    values = [v for v in counter.values() if v is not None and v > 0]
+    if not values:
+        return b""
+
     graph = cls()
     renames = {}
     for (source_prefix, target_prefix), count in counter.items():
@@ -507,7 +511,6 @@ def draw_counter(
     agraph.graph_attr["rankdir"] = direction
     agraph.graph_attr["directed"] = "true" if directed else "false"
 
-    values = [v for v in counter.values() if v is not None and v > 0]
     bottom, top = min(values), max(values)
     rr = top - bottom
 


### PR DESCRIPTION
mutations aren't configurable enough to make it possible to process taxranks correctly.

This PR already has tests for desired functionality, but the way mutations are encoded in configuration needs to get updated