### PR TITLE
Introduce new prioritization algorithm

### DIFF
--- a/src/semra/api.py
+++ b/src/semra/api.py
@@ -612,7 +612,7 @@ class Aggregator:
 
     def __init__(self, priority: Iterable[str]) -> None:
         """Initialize an aggregator."""
-        priority = _clean_priority_prefixes(priority)
+        priority = [bioregistry.normalize_prefix(prefix, strict=True) for prefix in priority]
         # sort such that the mappings are ordered by object by priority order
         # then identifier of object, then subject prefix in alphabetical order
         self.pos = {prefix: i for i, prefix in enumerate(priority)}
@@ -627,10 +627,6 @@ class Aggregator:
     def get_priority_reference(self, nodes: Iterable[Reference]) -> Reference:
         """Get a unique priority reference from a set of references."""
         return min(nodes, key=self.get_reference_key)
-
-
-def _clean_priority_prefixes(priority: Iterable[str]) -> list[str]:
-    return [bioregistry.normalize_prefix(prefix, strict=True) for prefix in priority]
 
 
 def get_priority_reference(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -499,9 +499,28 @@ class TestOperations(unittest.TestCase):
         m3 = Mapping(subject=a1, predicate=EXACT_MATCH, object=c1, evidence=[ev])
         m3_rev = Mapping(subject=c1, predicate=EXACT_MATCH, object=a1, evidence=[ev])
 
+        # Test on component with 1 edge
+        ###############################
+
+        self.assert_same_triples(
+            [m1_rev],
+            prioritize([m1, m1_rev], [PREFIX_A], progress=False),
+        )
+        self.assert_same_triples(
+            [m1],
+            prioritize([m1, m1_rev], [PREFIX_B], progress=False),
+        )
+        self.assert_same_triples(
+            [m1_rev],
+            prioritize([m1, m1_rev], [PREFIX_C], progress=False),
+        )
+
+        # Test on component with 2 edges
+        ################################
+
         # can't address priority
         self.assert_same_triples(
-            [],
+            [m1_rev, m3_rev],
             prioritize([m1, m1_rev, m2, m2_rev, m3, m3_rev], [PREFIX_D], progress=False),
         )
 
@@ -524,30 +543,11 @@ class TestOperations(unittest.TestCase):
             prioritize([m1, m1_rev, m2, m2_rev, m3, m3_rev], [PREFIX_C], progress=False),
         )
 
-        # test on component with only 1
-        self.assert_same_triples(
-            [m1_rev],
-            prioritize([m1, m1_rev], [PREFIX_A], progress=False),
-        )
-        self.assert_same_triples(
-            [m1],
-            prioritize([m1, m1_rev], [PREFIX_B], progress=False),
-        )
-        self.assert_same_triples(
-            [],
-            prioritize([m1, m1_rev], [PREFIX_C], progress=False),
-        )
-
-        # the following three tests reflect that the prioritize() function
-        # is not implemented in cases when inference hasn't been fully done
-        with self.assertRaises(NotImplementedError):
-            prioritize([m1, m2], [PREFIX_A], progress=False)
-        with self.assertRaises(NotImplementedError):
-            prioritize([m1, m2], [PREFIX_C], progress=False)
-
-        # this one is able to complete, by chance, but it's not part of
-        # the contract, so just left here for later
-        # self.assertEqual([m1, m2_rev], prioritize([m1, m2], [PREFIX_B], progress=False))
+        # FIXME note that in the following three cases, some mappings get thrown away. need to check if there's
+        #  an inverse in these cases
+        self.assert_same_triples([m2], prioritize([m1, m2], [PREFIX_A], progress=False))
+        self.assert_same_triples([m1], prioritize([m1, m2], [PREFIX_B], progress=False))
+        self.assert_same_triples([m2], prioritize([m1, m2], [PREFIX_C], progress=False))
 
 
 class TestUpgrades(unittest.TestCase):


### PR DESCRIPTION
Alternative to #80

The prioritization algorithm already assumed that a set of mappings had been processed with both inversion and chain inference.

Old algorithm:

1. Make an undirected graph
2. Get all connected components
3. In each connected component, get the highest priority node
4. Make mappings from each node to that one

This algorithm would produce incorrect results if there was no pre-existing mapping from a given node in a connected component to the highest priority node in the component (i.e., it would skip it entirely). This _should not_ have happened because of the precondition for using the function

New algorithm:

1. Still assume that inference has been run and that in each connected component, there are exact match mappings between all nodes (in both directions). Further, assume that `assemble_evidences()` has been run / there is only one exact match mapping for each subject/object pair
2. Make a subject-object-mapping index
3. For each subject
   1. assume that all objects comprise all nodes in the connected component that the subject belongs to. 
   2. choose the highest priority object from the list and the associated mapping with that object

Still todo:

- [ ] document/harden behavior for mapping sets that don't induce fully connected components
