### PR TITLE
Fix connected component query for graph display

### DIFF
--- a/src/semra/client.py
+++ b/src/semra/client.py
@@ -20,6 +20,7 @@ from typing_extensions import Self
 from semra.constants import SEMRA_EVIDENCE_PREFIX, SEMRA_MAPPING_PREFIX, SEMRA_MAPPING_SET_PREFIX
 from semra.rules import RELATIONS
 from semra.struct import Evidence, Mapping, MappingSet, Reference, SimpleEvidence
+from semra.vocabulary import CHAIN_MAPPING, INVERSION_MAPPING
 
 __all__ = [
     "BaseClient",
@@ -454,7 +455,7 @@ as label, count UNION ALL
         component_curies = {node["curie"] for node in nodes}
         # component_curies.add(curie)
 
-        edge_query = """\
+        edge_query = f"""\
             // There is a mapping between the two concepts
             MATCH p=(a:concept)-[r]->(b:concept)
             // We look up all mappings connecting them, making sure that we maintain
@@ -466,7 +467,7 @@ as label, count UNION ALL
             WHERE a <> b
             AND a.curie in $curies AND b.curie in $curies
             // Make sure the evidence is not an inversion of chaining
-            AND NOT (e.mapping_justification IN ['semapv:MappingInversion', 'semapv:MappingChaining'])
+            AND NOT (e.mapping_justification IN ['{CHAIN_MAPPING.curie}', '{INVERSION_MAPPING.curie}'])
             RETURN p
         """
         relations = [r[0] for r in self.read_query(edge_query, curies=sorted(component_curies))]

--- a/src/semra/client.py
+++ b/src/semra/client.py
@@ -200,7 +200,7 @@ class Neo4jClient(BaseClient):
         self.driver = neo4j.GraphDatabase.driver(uri=uri, auth=auth, max_connection_lifetime=180)
 
         self._all_relations = {curie for (curie,) in self.read_query(RELATIONS_CYPHER)}
-        self._rel_q = "|".join(
+        self._rel_q: str = "|".join(
             f"`{reference.curie}`"
             for reference in RELATIONS
             if reference.curie in self._all_relations

--- a/src/semra/web/fastapi_components.py
+++ b/src/semra/web/fastapi_components.py
@@ -46,7 +46,9 @@ def get_concept_cytoscape(
     ),
 ) -> JSONResponse:
     """Get the mapping graph surrounding the concept as a Cytoscape.js JSON object."""
-    graph = client.get_connected_component_graph(curie, relation_constraint=EXACT_MATCH.curie)
+    graph = client.get_connected_component_graph(
+        curie, relation_constraint=f"`{EXACT_MATCH.curie}`"
+    )
     if graph is None:
         raise HTTPException(status_code=404, detail=f"concept not found: {curie}")
     cytoscape_json = nx.cytoscape_data(graph)["elements"]

--- a/src/semra/web/fastapi_components.py
+++ b/src/semra/web/fastapi_components.py
@@ -11,6 +11,7 @@ from fastapi.responses import JSONResponse
 
 from semra import Evidence, Mapping, MappingSet, Reference
 from semra.client import BaseClient
+from semra.vocabulary import EXACT_MATCH
 from semra.web.shared import EXAMPLE_CONCEPTS
 
 __all__ = ["api_router"]
@@ -45,7 +46,7 @@ def get_concept_cytoscape(
     ),
 ) -> JSONResponse:
     """Get the mapping graph surrounding the concept as a Cytoscape.js JSON object."""
-    graph = client.get_connected_component_graph(curie)
+    graph = client.get_connected_component_graph(curie, relation_constraint=EXACT_MATCH)
     if graph is None:
         raise HTTPException(status_code=404, detail=f"concept not found: {curie}")
     cytoscape_json = nx.cytoscape_data(graph)["elements"]

--- a/src/semra/web/fastapi_components.py
+++ b/src/semra/web/fastapi_components.py
@@ -46,7 +46,7 @@ def get_concept_cytoscape(
     ),
 ) -> JSONResponse:
     """Get the mapping graph surrounding the concept as a Cytoscape.js JSON object."""
-    graph = client.get_connected_component_graph(curie, relation_constraint=EXACT_MATCH)
+    graph = client.get_connected_component_graph(curie, relation_constraint=EXACT_MATCH.curie)
     if graph is None:
         raise HTTPException(status_code=404, detail=f"concept not found: {curie}")
     cytoscape_json = nx.cytoscape_data(graph)["elements"]

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -87,10 +87,15 @@ class MockClient(BaseClient):
         """Get an empty summary."""
         return FullSummary()
 
-    def get_connected_component_graph(self, curie: ReferenceHint) -> nx.MultiDiGraph | None:
+    def get_connected_component_graph(
+        self, curie: ReferenceHint, relation_constraint: str | None = None
+    ) -> nx.MultiDiGraph | None:
         """Get a networkx MultiDiGraph representing the connected component of mappings around the given CURIE.
 
         :param curie: A CURIE string or reference
+        :param relation_constraint: Relation type constraints (separated by |)
+            to apply when considering relations in the connected component.
+            If None, defaults to the relations defined in the client.
 
         :returns: A networkx MultiDiGraph where mappings subject CURIE strings are th
         """


### PR DESCRIPTION
This PR fixes two issues with the way queries are done to get connected components in the web app.

Before

<img width="1338" height="970" alt="image" src="https://github.com/user-attachments/assets/3137b768-3fcd-4490-b1aa-d8f8218be3b8" />


After

<img width="1387" height="1089" alt="image" src="https://github.com/user-attachments/assets/f2b01bd0-b644-4a60-97b3-fae29b97ba50" />

To elaborate:
- First issue
  - The original query's intent was to filter to only mappings with primary and secondary evidence to avoid redundant mappings in the graph that are a result of inversion or chaining. 
  - However, this has the unintended effect of also filtering out mappings that are inferred from `hasDbXref` to `exactMatch` and are considered tertiary. 
  - This results in the graph being incomplete and not containing all the nodes that are actually part of the connected component (i.e., the terms that show up in the table on the same page).
  - To solve this, the query is made more explicit to specifically eliminate `semapv:MappingInversion` and `semapv:MappingChaining` which results in recovering the intended graph over the nodes in question.
  
- Second issue
  - The list of entities in the table above the graph comes from `get_exact_matches` which looks _only_ at `skos:exactMatch` as a relationship. In contrast, by default, `get_connected_component` uses `self._rel_q` by default which also includes `oboinowl:hasDbXref`. This has no effect when we're looking at a processed database, however, it is a major issue for a raw database where this difference results in a completely different graph.
  - To solve this, I also added an additional argument to `get_connected_component` and any other necessary places to pass in a custom relation constraint which, in the web app is set to just `skos:exactMatch`.
  - Overall, this ensures that the table of entities and the Cytoscape graph are fully consistent.