### PR TITLE
Restrict neo4j to compatible version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ web = [
     "uvicorn",
     "flask",
     "bootstrap_flask",
-    "neo4j",
+    "neo4j<6",
 ]
 landscape = [
     "upsetplot",


### PR DESCRIPTION
This PR restricts the neo4j version to <6 in pyproject.toml since the current client is not compatible with this most recent version of neo4j. This results in e.g., broken builds for Dockerized instances of SeMRA which currently, by default, install a 6+ version of the neo4j package. I tested that this change appears to solve this problem.